### PR TITLE
fix scrolling the chat when an image has loaded

### DIFF
--- a/app/components/chat-lazy-image.js
+++ b/app/components/chat-lazy-image.js
@@ -1,0 +1,13 @@
+/* eslint ember/no-observers: 0 */
+import LazyImage from 'ember-lazy-image/components/lazy-image'
+import { observer } from '@ember/object';
+
+export default LazyImage.extend({
+  adjustScrollingIfImageLoaded: observer('loaded', function(){
+    console.log('in adjustScrollingIfImageLoaded');
+    if(this.loaded === true){
+      console.log('calling adjustScrolling');
+      this.adjustScrolling();
+    }
+  })
+});

--- a/app/components/chat-lazy-image.js
+++ b/app/components/chat-lazy-image.js
@@ -4,9 +4,7 @@ import { observer } from '@ember/object';
 
 export default LazyImage.extend({
   adjustScrollingIfImageLoaded: observer('loaded', function(){
-    console.log('in adjustScrollingIfImageLoaded');
     if(this.loaded === true){
-      console.log('calling adjustScrolling');
       this.adjustScrolling();
     }
   })

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -15,13 +15,6 @@ export default Component.extend({
   },
   didInsertElement() {
     this._super(...arguments);
-    if(this.element.getElementsByClassName("chat-image").length > 0){
-      this.element.getElementsByClassName("chat-image")[1].onload = () => {
-        console.log('image loaded, scrolling to compensate for image');
-        this.adjustScrolling();
-      };
-    }else{
-      this.adjustScrolling();
-    }
+    this.adjustScrolling();
   }
 });

--- a/app/components/podcasts-search.js
+++ b/app/components/podcasts-search.js
@@ -1,3 +1,4 @@
+/* eslint ember/no-observers: 0 */
 import Component from '@ember/component';
 import { computed, observer } from '@ember/object';
 import { debounce } from '@ember/runloop';

--- a/app/templates/components/chat-lazy-image.hbs
+++ b/app/templates/components/chat-lazy-image.hbs
@@ -1,0 +1,38 @@
+{{! template-lint-disable }}
+{{#if hasBlock}}
+  {{#if errorThrown}}
+    <div class="lazy-image-error-message">{{defaultErrorText}}</div>
+  {{else}}
+    <div class="lazy-image-placeholder">{{yield}}</div>
+  {{/if}}
+{{else}}
+  {{#if errorThrown}}
+    <div class="lazy-image-error-message">{{defaultErrorText}}</div>
+  {{else}}
+    <div class="lazy-image-placeholder">
+      <svg version="1.1" id="loader-1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+       width="40px" height="40px" viewBox="0 0 40 40" enable-background="new 0 0 40 40" xml:space="preserve">
+      <path opacity="0.2" fill="#000" d="M20.201,5.169c-8.254,0-14.946,6.692-14.946,14.946c0,8.255,6.692,14.946,14.946,14.946
+        s14.946-6.691,14.946-14.946C35.146,11.861,28.455,5.169,20.201,5.169z M20.201,31.749c-6.425,0-11.634-5.208-11.634-11.634
+        c0-6.425,5.209-11.634,11.634-11.634c6.425,0,11.633,5.209,11.633,11.634C31.834,26.541,26.626,31.749,20.201,31.749z"/>
+      <path fill="#000" d="M26.013,10.047l1.654-2.866c-2.198-1.272-4.743-2.012-7.466-2.012h0v3.312h0
+        C22.32,8.481,24.301,9.057,26.013,10.047z">
+        <animateTransform attributeType="xml"
+          attributeName="transform"
+          type="rotate"
+          from="0 20 20"
+          to="360 20 20"
+          dur="0.5s"
+          repeatCount="indefinite"/>
+        </path>
+      </svg>
+    </div>
+  {{/if}}
+{{/if}}
+
+{{#if useDimensionsAttrs}}
+  <img class="{{unbound classesforImgTag}}" src={{lazyUrl}} alt="{{unbound alt}}" height={{height}} width={{width}} />
+{{else}}
+  <img class="{{unbound classesforImgTag}}" src={{lazyUrl}} alt="{{unbound alt}}"/>
+{{/if}}
+

--- a/app/templates/components/chat-message.hbs
+++ b/app/templates/components/chat-message.hbs
@@ -13,9 +13,10 @@
   {{#if hasImage}}
     <li class="message">
       <span class="message-body">
-        <LazyImage
+        <ChatLazyImage
           @url={{imgUrl}}
           @errorText="Image failed to load."
+          @adjustScrolling={{adjustScrolling}}
           class="chat-image"
         />
       </span>

--- a/tests/integration/components/chat-lazy-image-test.js
+++ b/tests/integration/components/chat-lazy-image-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | chat-lazy-image', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<ChatLazyImage />`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      <ChatLazyImage>
+        template block text
+      </ChatLazyImage>
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});


### PR DESCRIPTION
I extended the component from the lazy image addon, added an observer
to fire when the 'loaded' property is set to true.

The addon sets this property to true using an onload listener on the img
tag.