### PR TITLE
disable linting in the build

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -12,6 +12,8 @@ module.exports = function(defaults) {
     // Add options here
     fingerprint: fingerprintOptions,
 
+    hinting: false,
+
     'ember-font-awesome': {
       useScss: true, // for ember-cli-sass
     },


### PR DESCRIPTION
This will speed builds up. You won't be able to see linting errors in
the server console anymore, but I have my editor configured to show them
anyway and they are also ran on CI, so its not really necessary to run
them on every build I think.