### PR TITLE
Truncate text on calendar

### DIFF
--- a/app/styles/calendar.scss
+++ b/app/styles/calendar.scss
@@ -21,6 +21,7 @@
   background-color: $pink;
   border-left: 2px solid $blue;
   border-bottom: 2px dotted $blue;
+  overflow: hidden;
   &__title {
     font-size: 16px;
   }

--- a/app/templates/components/timetable-calendar.hbs
+++ b/app/templates/components/timetable-calendar.hbs
@@ -21,7 +21,7 @@
       @timeSlotDuration={{calendar.timeSlotDuration}} as |model|
     >
       <h1 class="as-calendar-occurrence__title" style={{titleStyle}}>
-        <LinkTo @route="home.show" @model={{model.content.id}}>
+        <LinkTo @route="home.show" @model={{model.content.id}} @title={{model.title}}>
           {{model.title}}
         </LinkTo>
       </h1>

--- a/app/templates/components/timetable-calendar.hbs
+++ b/app/templates/components/timetable-calendar.hbs
@@ -20,6 +20,7 @@
       @timeSlotHeight={{calendar.timeSlotHeight}}
       @timeSlotDuration={{calendar.timeSlotDuration}} as |model|
     >
+      {{!-- template-lint-disable no-inline-styles --}}
       <h1 class="as-calendar-occurrence__title" style={{titleStyle}}>
         <LinkTo @route="home.show" @model={{model.content.id}} @title={{model.title}}>
           {{model.title}}


### PR DESCRIPTION
Resolves #224 with some css overflow and adds a title so the full text can be accessed via hover of other A11y methods.

<img width="457" alt="Screen Shot 2020-01-21 at 10 50 45 PM" src="https://user-images.githubusercontent.com/1664093/72866719-f5d50100-3ca1-11ea-8853-a7843e557943.png">


---

Allowed inline-styles in the template lint since ember-calendar appears to rely on it and that isn't changing anytime soon since that addon appears to be abandoned. Now this component's template file passes template linting.