### PR TITLE
Fixed all template linting issues

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -8,10 +8,20 @@ export default {
   // },
   //
   // "key.with.interpolation": "Text with {{anInterpolation}}"
+  'site_title': 'datafruits',
+  'site_title_fm': 'datafruits.fm',
   'home': {
     'upcoming_shows': 'UPCOMING SHOWS',
     'latest_podcasts': 'LATEST PODCASTS',
-    'events': 'EVENTS'
+    'events': 'EVENTS',
+    'podcasts': {
+      'title': 'PODCASTS',
+      'subscribe_request': 'Subscribe to the datafruits.fm podcast',
+      'link_itunes': 'iTunes',
+      'link_overcast': 'Overcast',
+      'link_podcastsapp': 'Podcasts.app',
+      'link_rss': 'RSS',
+    },
   },
   'chat': {
     'title': 'Chat',
@@ -20,11 +30,19 @@ export default {
     'send': "Send",
     'message_placeholder': "enter your message here...",
     'join': "Join chat",
-    'nickname': "nickname"
+    'nickname': "nickname",
+    'gif': 'GIF',
+  },
+  '404': {
+    'title': '404!',
+    'message': 'Page not found',
+    'return_linktext': 'back to safety',
   },
   'podcasts': {
     'title': 'Podcast',
     'no_result': 'No results. Musta been the onion salad dressing.',
+    'pagination_prev': '«',
+    'pagination_next': '»',
     'text_search': {
       'label': 'Search by free text'
     },
@@ -36,12 +54,19 @@ export default {
   'djs': {
     'title': 'DJs'
   },
+  'nav_toggle': 'Toggle navigation',
   'radio': 'Radio',
   'label': 'Label',
   'about': 'About',
   'blog': 'Blog',
   'shop': 'Shop',
+  'thanks': 'Thanks!',
   'subscribe': 'Subscribe',
+  'newsletter_modal': {
+    'title': 'DATAFRUITS.FM NEWSLETTER',
+    'placeholder_email': 'Email',
+    'tiny': '(Free exclusive tracks, mixes & info)',
+  },
   'djinquiry': {
     'title': 'DJ on Datafruits',
     'heading': 'Want to have your own show on Datafruits?',
@@ -57,6 +82,15 @@ export default {
   },
   'just_a_website': "It's just a website.",
   'about_datafruits': "Datafruits is a netradio and label founded in 2012 by Tony Miller (mcfiredrill). Its mission is to bring you the world's strangest sounds and bring together the music communities around the world.",
+  'twitter': 'Twitter',
+  'tweet': 'Tweet',
+  'github': 'Github',
+  'soundcloud': 'Soundcloud',
+  'mixcloud': 'Mixcloud',
+  'instagram': 'Instagram',
+  'email': 'Email info@datafruits.fm',
+  'patron': 'Patreon',
+  'secret': 'secret',
   'thanks_patrons': "THANKS TO ALL THE PATRONS!",
   'code_of_conduct': 'Code Of Conduct',
   'what_is_datafruits': 'What is datafruits...',
@@ -68,9 +102,66 @@ export default {
     'upcoming_shows': 'Upcoming show'
   },
   'show': {
+    'hosted_prefix': 'Hosted by:',
     'archive': 'Listen back to the podcast',
   },
   'player': {
-    'play_button_label': 'play'
-  }
+    'play_button_label': 'play',
+    'return_to_live': 'return to live stream',
+    'loading': '↻',
+    'pause': '❚❚',
+    'play': '▶︎',
+    'compatibility': {
+      'warning': 'To view this video please enable JavaScript, and consider upgrading to a web browser that',
+      'linktext': 'supports HTML5 video',
+    },
+  },
+  'about_page': {
+    'listenersupport': 'Datafruits is listener supported. You can join our patreon and get stickers and other goodies sent to you every 2 months.',
+    'donate_request': 'Or if you\'d like you can make a one time donation to our paypal.',
+    'donate_linktext': 'https://paypal.me/datafruitsfm',
+  },
+  'coc': {
+    'pledge': {
+      'title': 'Our Pledge',
+      'p1': 'In the interest of fostering an open and welcoming environment, we as music fans pledge to making participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.',
+    },
+    'standards': {
+      'title': 'Our Standards',
+      'p1': 'Examples of behavior that contributes to creating a positive environment include:',
+      'p1_bullet1': 'Using welcoming and inclusive language',
+      'p1_bullet2': 'Being respectful of differing viewpoints and experiences',
+      'p1_bullet3': 'Gracefully accepting constructive criticism',
+      'p1_bullet4': 'Focusing on what is best for the community',
+      'p1_bullet5': 'Showing empathy towards other community members',
+      'p2': 'Examples of unacceptable behavior by participants include:',
+      'p2_bullet1': 'The use of sexualized language or imagery and unwelcome sexual attention or advances',
+      'p2_bullet2': 'Trolling, insulting/derogatory comments, and personal or political attacks',
+      'p2_bullet3': 'Public or private harassment',
+      'p2_bullet4': 'Publishing others\' private information, such as a physical or electronic address, without explicit permission',
+      'p2_bullet5': 'Other conduct which could reasonably be considered inappropriate',
+    },
+    'responsibilities': {
+      'title': 'Our Responsibilities',
+      'p1': 'Datafruits administrators are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.',
+      'p2': 'Datafruits administrators have the right and responsibility to remove, edit, or reject  contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any user for other behaviors that they deem inappropriate, threatening, offensive, or harmful.',
+    },
+    'scope': {
+      'title': 'Scope',
+      'p1': 'This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by datafruits administrators.',
+    },
+    'enforcement': {
+      'title': 'Enforcement',
+      'p1_part1': 'Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the datafruits administrators (email',
+      'p1_part2': '). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.',
+      'p1_linktext': 'info@datafruits.fm',
+      'p2': 'Datafruits administrators who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project\'s leadership.',
+    },
+    'attribution': {
+      'title': 'Attribution',
+      'p1_part1': 'This Code of Conduct is adapted from the the Rubygems Contributor Covenant, which was in turn adopted from the Contributor Covenant, version 1.4, available at',
+      'p1_part2': '.',
+      'p1_linktext': 'http://contributor-covenant.org/version/1/4',
+    },
+  },
 };

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -57,6 +57,10 @@ body {
   font-family: Helvetica, Arial, sans-serif;
 }
 
+.hide {
+  display: none;
+}
+
 h1#logo {
   font-family: 'debussy', sans-serif;
   transform: rotate(-3deg);

--- a/app/templates/components/blog-post-preview.hbs
+++ b/app/templates/components/blog-post-preview.hbs
@@ -5,7 +5,7 @@
 </h3>
 <article>
   <img
-    width='300'
+    width="300"
     src={{body.previewImage.cdnUrl}}
     alt={{body.previewImage.imageFileName}}
   >

--- a/app/templates/components/container/datafruits-player.hbs
+++ b/app/templates/components/container/datafruits-player.hbs
@@ -19,21 +19,19 @@
         {{t "player.pause"}}
       </a>
     {{else if paused}}
-      <a
+      <a {{action "play"}}
         onMouseEnter={{action "playButtonMouseEnter"}}
         onMouseLeave={{action "playButtonMouseOut"}}
         class="jp-play"
         href="javascript:;"
         tabindex="1"
-        {{action "play"}}
       >
         {{t "player.play"}}
       </a>
     {{/if}}
-    <span
+    <span {{action "toggleVolumeControl" on="mouseEnter"}}
       class="jp-volume-controls"
       role="button"
-      {{action "toggleVolumeControl" on="mouseEnter"}}
     >
       {{#if muted}}
         {{!-- template-lint-disable no-nested-interactive --}}

--- a/app/templates/components/container/datafruits-player.hbs
+++ b/app/templates/components/container/datafruits-player.hbs
@@ -2,21 +2,21 @@
   <source
     src="https://streampusher-relay.club/datafruits.mp3"
     type="audio/mp3"
-  />
+  >
   <source
     src="https://streampusher-relay.club/datafruits.ogg"
     type="audio/ogg"
-  />
+  >
 </audio>
 <div class="radio-container">
   <div class="player-controls">
     {{#if loading}}
       <a class="jp-loading" href="javascript:;" tabindex="1">
-        ↻
+        {{t "player.loading"}}
       </a>
     {{else if playing}}
       <a class="jp-pause" tabindex="1" {{action "pause"}}>
-        ❚❚
+        {{t "player.pause"}}
       </a>
     {{else if paused}}
       <a
@@ -27,14 +27,16 @@
         tabindex="1"
         {{action "play"}}
       >
-        ▶︎
+        {{t "player.play"}}
       </a>
     {{/if}}
     <span
       class="jp-volume-controls"
+      role="button"
       {{action "toggleVolumeControl" on="mouseEnter"}}
     >
       {{#if muted}}
+        {{!-- template-lint-disable no-nested-interactive --}}
         <a class="jp-unmute" tabindex="1" {{action "unmute"}}>
           <i class="fa fa-volume-off"></i>
         </a>
@@ -52,7 +54,7 @@
           step="0.1"
           oninput={{action "volumeChanged"}}
           value={{volume}}
-        />
+        >
       {{/if}}
     </span>
   </div>
@@ -77,7 +79,7 @@
         step="any"
         oninput={{action "seek"}}
         value={{playTime}}
-      />
+      >
     </div>
   </div>
 {{/if}}

--- a/app/templates/components/datafruits-chat-input-message.hbs
+++ b/app/templates/components/datafruits-chat-input-message.hbs
@@ -23,5 +23,5 @@
     <GiphySearch @sendGif={{action "sendGif"}} />
   </div>
 {{else}}
-  <button class="cool-button" {{action 'showGifSearch'}}>GIF</button>
+  <button class="cool-button" {{action "showGifSearch"}}>{{t "chat.gif"}}</button>
 {{/if}}

--- a/app/templates/components/datafruits-chat-input-message.hbs
+++ b/app/templates/components/datafruits-chat-input-message.hbs
@@ -6,18 +6,19 @@
   placeholder={{t "chat.message_placeholder"}}
   @autofocus="autofocus"
 />
-<button
+<button {{action "sendMessage"}}
   type="submit"
   class="cool-button"
   id="send-message-button"
   disabled={{isOffline}}
-  {{action "sendMessage"}}>
+>
   {{t "chat.send"}}
 </button>
 {{#if showingGifSearch}}
   <div class="gif-search">
-    <button class="cool-button"
-      {{action "closeGifSearch"}}>
+    <button {{action "closeGifSearch"}}
+      class="cool-button"
+    >
       <i class="fa fa-times"></i>
     </button>
     <GiphySearch @sendGif={{action "sendGif"}} />

--- a/app/templates/components/datafruits-chat.hbs
+++ b/app/templates/components/datafruits-chat.hbs
@@ -41,10 +41,9 @@
         @autocapitalize="none"
         placeholder={{t "chat.nickname"}}
       />
-      <button
+      <button {{action "enterChat"}}
         class="cool-button"
         disabled={{or disableJoinButton networkStatus.isOffline}}
-        {{action "enterChat"}}
       >
         {{t "chat.join"}}
       </button>

--- a/app/templates/components/datafruits-player.hbs
+++ b/app/templates/components/datafruits-player.hbs
@@ -2,26 +2,26 @@
   <source
     src="https://streampusher-relay.club/datafruits.mp3"
     type="audio/mp3"
-  />
+  >
   <source
     src="https://streampusher-relay.club/datafruits.ogg"
     type="audio/ogg"
-  />
+  >
 </audio>
 <div class="radio-container">
   <div class="player-controls">
     {{#if playingPodcast}}
-      <a {{action "playLiveStream"}}>
-        return to live stream
+      <a href="javascript:;" {{action "playLiveStream"}}>
+        {{t "player.return_to_live"}}
       </a>
     {{/if}}
     {{#if loading}}
       <a class="jp-loading" href="javascript:;" tabindex="1">
-        ↻
+        {{t "player.loading"}}
       </a>
     {{else if playing}}
       <a class="jp-pause" tabindex="1" {{action "pause"}}>
-        ❚❚
+        {{t "player.pause"}}
       </a>
     {{else if paused}}
       <a
@@ -34,14 +34,16 @@
         aria-label={{t "player.play_button_label"}}
         {{action "play"}}
       >
-        ▶︎
+        {{t "player.play"}}
       </a>
     {{/if}}
     <span
       class="jp-volume-controls"
+      role="button"
       {{action "toggleVolumeControl" on="mouseEnter"}}
     >
       {{#if muted}}
+        {{!-- template-lint-disable no-nested-interactive --}}
         <a class="jp-unmute" tabindex="1" {{action "unmute"}}>
           <i class="fa fa-volume-off"></i>
         </a>
@@ -59,7 +61,7 @@
           step="0.1"
           oninput={{action "volumeChanged"}}
           value={{volume}}
-        />
+        >
       {{/if}}
     </span>
   </div>
@@ -95,7 +97,7 @@
         step="any"
         oninput={{action "seek"}}
         value={{playTime}}
-      />
+      >
     </div>
   </div>
 {{/if}}

--- a/app/templates/components/datafruits-player.hbs
+++ b/app/templates/components/datafruits-player.hbs
@@ -24,7 +24,7 @@
         {{t "player.pause"}}
       </a>
     {{else if paused}}
-      <a
+      <a {{action "play"}}
         onMouseEnter={{action "playButtonMouseEnter"}}
         onMouseLeave={{action "playButtonMouseOut"}}
         class="jp-play"
@@ -32,15 +32,13 @@
         tabindex="1"
         role="button"
         aria-label={{t "player.play_button_label"}}
-        {{action "play"}}
       >
         {{t "player.play"}}
       </a>
     {{/if}}
-    <span
+    <span {{action "toggleVolumeControl" on="mouseEnter"}}
       class="jp-volume-controls"
       role="button"
-      {{action "toggleVolumeControl" on="mouseEnter"}}
     >
       {{#if muted}}
         {{!-- template-lint-disable no-nested-interactive --}}

--- a/app/templates/components/datafruits-visuals.hbs
+++ b/app/templates/components/datafruits-visuals.hbs
@@ -8,9 +8,10 @@
     muted
   >
     <p class="vjs-no-js">
-      To view this video please enable JavaScript, and consider upgrading to a web browser that
+      {{t "player.compatibility.warning"}}
+      {{!-- template-lint-disable no-nested-interactive --}}
       <a href="http://videojs.com/html5-video-support/" target="_blank" rel="noopener">
-        supports HTML5 video
+        {{t "player.compatibility.linktext"}}
       </a>
     </p>
   </video>

--- a/app/templates/components/datafruits-visuals.hbs
+++ b/app/templates/components/datafruits-visuals.hbs
@@ -10,7 +10,11 @@
     <p class="vjs-no-js">
       {{t "player.compatibility.warning"}}
       {{!-- template-lint-disable no-nested-interactive --}}
-      <a href="http://videojs.com/html5-video-support/" target="_blank" rel="noopener">
+      <a
+        href="http://videojs.com/html5-video-support/"
+        target="_blank"
+        rel="noopener"
+      >
         {{t "player.compatibility.linktext"}}
       </a>
     </p>

--- a/app/templates/components/giphy-loader.hbs
+++ b/app/templates/components/giphy-loader.hbs
@@ -1,4 +1,5 @@
-{{yield (hash
+{{yield
+  (hash
     isRunning=fetchData.isRunning
     data=data)
 }}

--- a/app/templates/components/giphy-search.hbs
+++ b/app/templates/components/giphy-search.hbs
@@ -15,7 +15,7 @@
           class="gif-preview"
           alt={{gif.name}}
           src={{gif.previewUrl}}
-          >
+        >
       </button>
     {{/each}}
   {{/if}}

--- a/app/templates/components/pc-nav.hbs
+++ b/app/templates/components/pc-nav.hbs
@@ -69,6 +69,6 @@
     </ul>
   {{/if}}
   <LinkTo @route="home">
-    <img id="circle-logo" src="/assets/images/logo.png" />
+    <img id="circle-logo" src="/assets/images/logo.png" alt={{t "site_title"}}>
   </LinkTo>
 </nav>

--- a/app/templates/components/pc-nav.hbs
+++ b/app/templates/components/pc-nav.hbs
@@ -1,16 +1,16 @@
 <nav class="navbar pc" role="navigation">
   <ul>
     <li class="subnav">
-      <a
+      <a {{action toggleSubMenu on="mouseEnter"}}
         class="submenu-title"
         href="#"
-        {{action toggleSubMenu on="mouseEnter"}}
       >
         {{t "radio"}}
         <span
           class="fa fa-arrow-circle-o-right {{if submenuOpen "rotated"}}"
           aria-hidden="true"
-        ></span>
+        >
+        </span>
       </a>
     </li>
     <li>

--- a/app/templates/components/podcast-track.hbs
+++ b/app/templates/components/podcast-track.hbs
@@ -1,11 +1,11 @@
 <div class="podcast">
   {{#if playing}}
-    <a class="podcast-controls" {{action "pause"}}>
-      ❚❚
+    <a class="podcast-controls" {{action "pause"}} href="#">
+      {{t "player.pause"}}
     </a>
   {{else}}
-    <a class="podcast-controls" {{action "play"}}>
-      ▶︎
+    <a class="podcast-controls" {{action "play"}} href="#">
+      {{t "player.play"}}
     </a>
   {{/if}}
   <a href={{cdnUrl}} download="">
@@ -29,7 +29,7 @@
     {{title}}
   {{/if}}
   {{#each labels as |label|}}
-    <a class="track-label" {{action selectLabel label}}>
+    <a class="track-label" {{action selectLabel label}} href="#">
       {{label.name}}
     </a>
   {{/each}}

--- a/app/templates/components/podcast-track.hbs
+++ b/app/templates/components/podcast-track.hbs
@@ -12,7 +12,12 @@
     <i class="fa fa-download"></i>
   </a>
   {{#if soundcloudKey}}
-    <a class="podcast-controls" href={{soundcloudKey}} target="_blank" rel="noopener">
+    <a
+      class="podcast-controls"
+      href={{soundcloudKey}}
+      target="_blank"
+      rel="noopener"
+    >
       <i class="fa fa-soundcloud"></i>
     </a>
   {{/if}}

--- a/app/templates/components/podcasts-search.hbs
+++ b/app/templates/components/podcasts-search.hbs
@@ -43,7 +43,7 @@
           @route="home.podcasts"
           @query={{hash page=(dec loader.data.meta.page)}}
         >
-          «
+          {{t "podcasts.pagination_prev"}}
         </LinkTo>
       </span>
     {{/if}}
@@ -64,7 +64,7 @@
           @route="home.podcasts"
           @query={{hash page=(inc loader.data.meta.page)}}
         >
-          »
+          {{t "podcasts.pagination_next"}}
         </LinkTo>
       </span>
     {{/if}}

--- a/app/templates/components/sp-nav.hbs
+++ b/app/templates/components/sp-nav.hbs
@@ -1,7 +1,7 @@
 <nav class="navbar sp" role="navigation">
   <button type="button" class="navbar-toggle collapsed" {{action toggleMenu}}>
     <span class="sr-only">
-      Toggle navigation
+      {{t "nav_toggle"}}
     </span>
     <span class="fa fa-bars" aria-hidden="true"></span>
   </button>
@@ -66,7 +66,7 @@
       </li>
     </ul>
   {{/if}}
-  <LinkTo @route="home" @aria-label={{t 'blog'}}>
-    <img id="circle-logo" src="/assets/images/logo.png" />
+  <LinkTo @route="home" @aria-label={{t "blog"}}>
+    <img id="circle-logo" src="/assets/images/logo.png" alt={{t "site_title"}}>
   </LinkTo>
 </nav>

--- a/app/templates/components/tweet-button.hbs
+++ b/app/templates/components/tweet-button.hbs
@@ -1,7 +1,7 @@
 <a
   href="https://twitter.com/share"
   class="twitter-share-button"
-  data-text="{{text}}"
+  data-text={{text}}
 >
-  Tweet
+  {{t "tweet"}}
 </a>

--- a/app/templates/container/index.hbs
+++ b/app/templates/container/index.hbs
@@ -1,4 +1,4 @@
 <Container::DatafruitsPlayer />
-<a class="logo" href="https://datafruits.fm/" target="_blank">
-  <img id="circle-logo" src="/assets/images/logo.png" />
+<a class="logo" href="https://datafruits.fm/" target="_blank" rel="noopener">
+  <img id="circle-logo" src="/assets/images/logo.png" alt={{t "site_title"}}>
 </a>

--- a/app/templates/container/show.hbs
+++ b/app/templates/container/show.hbs
@@ -3,6 +3,12 @@
 {{else}}
   <Container::DatafruitsPlayer />
 {{/if}}
-<a class="logo" href="https://datafruits.fm/" target="_blank" rel="noopener" aria-label={{t "site_title_fm"}}>
+<a
+  class="logo"
+  href="https://datafruits.fm/"
+  target="_blank"
+  rel="noopener"
+  aria-label={{t "site_title_fm"}}
+>
   <img id="circle-logo" src="/assets/images/logo.png" alt={{t "site_title"}}>
 </a>

--- a/app/templates/container/show.hbs
+++ b/app/templates/container/show.hbs
@@ -3,6 +3,6 @@
 {{else}}
   <Container::DatafruitsPlayer />
 {{/if}}
-<a class="logo" href="https://datafruits.fm/" target="_blank" rel="noopener" aria-label="datafruits.fm">
-  <img id="circle-logo" src="/assets/images/logo.png" />
+<a class="logo" href="https://datafruits.fm/" target="_blank" rel="noopener" aria-label={{t "site_title_fm"}}>
+  <img id="circle-logo" src="/assets/images/logo.png" alt={{t "site_title"}}>
 </a>

--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -6,7 +6,7 @@
   <SpNav @toggleMenu={{action "toggleMenu"}} @menuOpen={{menuOpen}} />
   <LinkTo @route="home">
     <h1 id="logo">
-      datafruits.fm
+      {{t "site_title_fm"}}
     </h1>
   </LinkTo>
   {{outlet}}

--- a/app/templates/home/about.hbs
+++ b/app/templates/home/about.hbs
@@ -15,16 +15,16 @@
       </li>
       <li>
         <p>
-          Datafruits is listener supported. You can join our patreon and get stickers and other goodies sent to you every 2 months.
+          {{t "about_page.listenersupport"}}
         </p>
         <a href="https://patreon.com/datafruits" target="_blank" rel="noopener">
-          Patreon
+          {{t "patron"}}
         </a>
         <p>
-          Or if you'd like you can make a one time donation to our paypal.
+          {{t "about_page.donate_request"}}
         </p>
         <a href="https://paypal.me/datafruitsfm" target="_blank" rel="noopener">
-          https://paypal.me/datafruitsfm
+          {{t "about_page.donate_linktext"}}
         </a>
       </li>
     </ul>
@@ -44,7 +44,7 @@
       <li>
         <a
           href="http://twitter.com/datafruits"
-          title="twitter"
+          title={{t "twitter"}}
           target="_blank"
           rel="noopener"
         >
@@ -54,7 +54,7 @@
       <li>
         <a
           href="http://github.com/datafruits"
-          title="github"
+          title={{t "github"}}
           target="_blank"
           rel="noopener"
         >
@@ -64,7 +64,7 @@
       <li>
         <a
           href="http://soundcloud.com/datafruits"
-          title="soundcloud"
+          title={{t "soundcloud"}}
           target="_blank"
           rel="noopener"
         >
@@ -74,7 +74,7 @@
       <li>
         <a
           href="http://mixcloud.com/datafruits"
-          title="mixcloud"
+          title={{t "mixcloud"}}
           target="_blank"
           rel="noopener"
         >
@@ -84,7 +84,7 @@
       <li>
         <a
           href="http://instagram.com/datafruits"
-          title="instagram"
+          title={{t "instagram"}}
           target="_blank"
           rel="noopener"
         >
@@ -94,7 +94,7 @@
       <li>
         <a
           href="mailto:info@datafruits.fm"
-          title="mail"
+          title={{t "email"}}
           target="_blank"
           rel="noopener"
         >
@@ -102,109 +102,109 @@
         </a>
       </li>
     </ul>
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
-    <br />
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
+    <br>
     <a href="http://datavegetables.club" class="secret">
-      secret
+      {{t "secret"}}
     </a>
   </div>
 </div>

--- a/app/templates/home/chat.hbs
+++ b/app/templates/home/chat.hbs
@@ -1,8 +1,4 @@
-{{#unless fastboot.isFastBoot}}
-  <NetworkStatus as |status|>
-    <DatafruitsChat @networkStatus={{status}} />
-  </NetworkStatus>
-{{else}}
+{{#if fastboot.isFastBoot}}
   <div class="main-content">
     <div class="loading-container">
       <img alt={{t "loading"}} src={{random-loading-spinner}}>
@@ -11,4 +7,8 @@
       <h1>{{random-loading-message}}</h1>
     </div>
   </div>
-{{/unless}}
+{{else}}
+  <NetworkStatus as |status|>
+    <DatafruitsChat @networkStatus={{status}} />
+  </NetworkStatus>
+{{/if}}

--- a/app/templates/home/coc.hbs
+++ b/app/templates/home/coc.hbs
@@ -1,90 +1,90 @@
 {{title "Code Of Conduct"}}
 <div class="main-content">
-  <h1>
-    Our Pledge
-  </h1>
+  <h2>
+    {{t "coc.pledge.title"}}
+  </h2>
   <p>
-    In the interest of fostering an open and welcoming environment, we as music fans pledge to making participation in our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+    {{t "coc.pledge.p1"}}
   </p>
-  <h1>
-    Our Standards
-  </h1>
+  <h2>
+    {{t "coc.standards.title"}}
+  </h2>
   <p>
-    Examples of behavior that contributes to creating a positive environment include:
-  </p>
-  <ul>
-    <li>
-      Using welcoming and inclusive language
-    </li>
-    <li>
-      Being respectful of differing viewpoints and experiences
-    </li>
-    <li>
-      Gracefully accepting constructive criticism
-    </li>
-    <li>
-      Focusing on what is best for the community
-    </li>
-    <li>
-      Showing empathy towards other community members
-    </li>
-  </ul>
-  <p>
-    Examples of unacceptable behavior by participants include:
+    {{t "coc.standards.p1"}}
   </p>
   <ul>
     <li>
-      The use of sexualized language or imagery and unwelcome sexual attention or advances
+      {{t "coc.standards.p1_bullet1"}}
     </li>
     <li>
-      Trolling, insulting/derogatory comments, and personal or political attacks
+      {{t "coc.standards.p1_bullet2"}}
     </li>
     <li>
-      Public or private harassment
+      {{t "coc.standards.p1_bullet3"}}
     </li>
     <li>
-      Publishing others' private information, such as a physical or electronic address, without explicit permission
+      {{t "coc.standards.p1_bullet4"}}
     </li>
     <li>
-      Other conduct which could reasonably be considered inappropriate
+      {{t "coc.standards.p1_bullet5"}}
     </li>
   </ul>
-  <h1>
-    Our Responsibilities
-  </h1>
   <p>
-    Datafruits administrators are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+    {{t "coc.standards.p2"}}
+  </p>
+  <ul>
+    <li>
+      {{t "coc.standards.p2_bullet1"}}
+    </li>
+    <li>
+      {{t "coc.standards.p2_bullet2"}}
+    </li>
+    <li>
+      {{t "coc.standards.p2_bullet3"}}
+    </li>
+    <li>
+      {{t "coc.standards.p2_bullet4"}}
+    </li>
+    <li>
+      {{t "coc.standards.p2_bullet5"}}
+    </li>
+  </ul>
+  <h2>
+    {{t "coc.responsibilities.title"}}
+  </h2>
+  <p>
+    {{t "coc.responsibilities.p1"}}
   </p>
   <p>
-    Datafruits administrators have the right and responsibility to remove, edit, or reject  contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any user for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+    {{t "coc.responsibilities.p2"}}
   </p>
-  <h1>
-    Scope
-  </h1>
+  <h2>
+    {{t "coc.scope.title"}}
+  </h2>
   <p>
-    This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by datafruits administrators.
+    {{t "coc.scope.p1"}}
   </p>
-  <h1>
-    Enforcement
-  </h1>
+  <h2>
+    {{t "coc.enforcement.title"}}
+  </h2>
   <p>
-    Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the datafruits administrators (email
+    {{t "coc.enforcement.p1_part1"}}
     <a href="mailto:info@datafruits.fm">
-      info@datafruits.fm
+      {{t "coc.enforcement.p1_linktext"}}
     </a>
-    ). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+    {{t "coc.enforcement.p1_part2"}}
   </p>
   <p>
-    Datafruits administrators who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+    {{t "coc.enforcement.p2"}}
   </p>
-  <h1>
-    Attribution
-  </h1>
+  <h2>
+    {{t "coc.attribution.title"}}
+  </h2>
   <p>
-    This Code of Conduct is adapted from the the Rubygems Contributor Covenant, which was in turn adopted from the Contributor Covenant, version 1.4, available at
+    {{t "coc.attribution.p1_part1"}}
     <a href="http://contributor-covenant.org/version/1/4" target="_blank" rel="noopener">
-      http://contributor-covenant.org/version/1/4
+      {{t "coc.attribution.p1_linktext"}}
     </a>
-    .
+    {{t "coc.attribution.p1_part2"}}
   </p>
 </div>

--- a/app/templates/home/coc.hbs
+++ b/app/templates/home/coc.hbs
@@ -82,7 +82,11 @@
   </h2>
   <p>
     {{t "coc.attribution.p1_part1"}}
-    <a href="http://contributor-covenant.org/version/1/4" target="_blank" rel="noopener">
+    <a
+      href="http://contributor-covenant.org/version/1/4"
+      target="_blank"
+      rel="noopener"
+    >
       {{t "coc.attribution.p1_linktext"}}
     </a>
     {{t "coc.attribution.p1_part2"}}

--- a/app/templates/home/dj-inquiry.hbs
+++ b/app/templates/home/dj-inquiry.hbs
@@ -1,9 +1,9 @@
 {{title (t "djinquiry.title")}}
 <div class="main-content">
   <h1 id="myModalLabel">
-    <img src="{{random-loading-spinner}}" />
+    <img src={{random-loading-spinner}} alt={{t "loading"}}>
     {{t "djinquiry.heading"}}
-    <img src="{{random-loading-spinner}}" />
+    <img src={{random-loading-spinner}} alt={{t "loading"}}>
   </h1>
   <div class="modal-body">
     <p>
@@ -21,7 +21,7 @@
             <label>
               {{t "djinquiry.email"}}
             </label>
-            <br />
+            <br>
             <Input @value={{model.email}} />
             {{#if model.errors.email}}
               {{#each model.errors.email as |error|}}
@@ -37,7 +37,7 @@
             <label>
               {{t "djinquiry.username"}}
             </label>
-            <br />
+            <br>
             <Input @value={{model.username}} />
             {{#if model.errors.username}}
               {{#each model.errors.username as |error|}}
@@ -53,7 +53,7 @@
             <label>
               {{t "djinquiry.link_to_mix"}}
             </label>
-            <br />
+            <br>
             <Input @value={{model.link}} />
             {{#if model.errors.link}}
               {{#each model.errors.link as |error|}}
@@ -69,7 +69,7 @@
             <label>
               {{t "djinquiry.interval"}}
             </label>
-            <br />
+            <br>
             <select onchange={{action "setInterval"}} value="target.value">
               {{#each intervals as |interval|}}
                 {{#if (eq model.interval interval)}}
@@ -88,7 +88,7 @@
             <label>
               {{t "djinquiry.time"}}
             </label>
-            <br />
+            <br>
             <Textarea @value={{model.desiredTime}} />
             {{#if model.errors.desiredTime}}
               {{#each model.errors.desiredTime as |error|}}
@@ -104,7 +104,7 @@
             <label>
               {{t "djinquiry.other"}}
             </label>
-            <br />
+            <br>
             <Textarea @value={{model.otherComment}} />
           </div>
           <div>
@@ -113,14 +113,14 @@
               value="Send"
               class="cool-button"
               disabled={{model.isSaving}}
-            />
+            >
           </div>
         </form>
       </p>
     {{else}}
       <p>
-        <img src="/assets/images/thanks.gif" />
-        <br />
+        <img src="/assets/images/thanks.gif" alt={{t "thanks"}}>
+        <br>
         {{t "djinquiry.thanks"}}
       </p>
     {{/if}}

--- a/app/templates/home/dj.hbs
+++ b/app/templates/home/dj.hbs
@@ -4,7 +4,7 @@
       <h1 class="dj-title">
         {{model.username}}
       </h1>
-      <img src={{model.imageMediumUrl}} alt={{model.username}} />
+      <img src={{model.imageMediumUrl}} alt={{model.username}}>
       <p>
         {{model.bio}}
       </p>

--- a/app/templates/home/djs.hbs
+++ b/app/templates/home/djs.hbs
@@ -13,14 +13,14 @@
             height="150"
             src="/assets/images/dj_placeholder.png"
             alt={{dj.username}}
-          />
+          >
         {{else}}
           <img
             width="150"
             height="150"
             src={{dj.imageThumbUrl}}
             alt={{dj.username}}
-          />
+          >
         {{/if}}
       </div>
     {{/each}}

--- a/app/templates/home/index.hbs
+++ b/app/templates/home/index.hbs
@@ -27,21 +27,21 @@
                 height="300"
                 src={{show.thumbImageUrl}}
                 alt={{show.title}}
-              />
+              >
             {{else if show.host.imageUrl}}
               <img
                 width="300"
                 height="300"
                 src={{show.host.imageUrl}}
                 alt={{show.title}}
-              />
+              >
             {{else}}
               <img
                 width="300"
                 height="300"
                 src="/assets/images/show_placeholder.jpg"
                 alt={{show.title}}
-              />
+              >
             {{/if}}
           </LinkTo>
         </div>
@@ -61,12 +61,12 @@
               height="300"
               src={{track.scheduledShow.thumbImageUrl}}
               alt={{track.title}}
-            />
+            >
           {{else}}
             <img
               src="/assets/images/show_placeholder.jpg"
               alt={{track.title}}
-            />
+            >
           {{/if}}
         </LinkTo>
         <LinkTo @route="home.show" @model={{track.scheduledShow.id}}>

--- a/app/templates/home/loading.hbs
+++ b/app/templates/home/loading.hbs
@@ -1,6 +1,6 @@
 <div class="main-content">
   <div class="loading-container">
-    <img src="{{random-loading-spinner}}" />
+    <img src={{random-loading-spinner}} alt={{t "loading"}}>
   </div>
   <div class="loading-container">
     <h1>

--- a/app/templates/home/podcasts.hbs
+++ b/app/templates/home/podcasts.hbs
@@ -1,24 +1,24 @@
 {{title (t "podcasts.title")}}
 <div class="main-content">
   <h1>
-    PODCASTS
+    {{t "home.podcasts.title"}}
   </h1>
   <div>
     <h4>
-      Subscribe to the datafruits.fm podcast
+      {{t "home.podcasts.subscribe_request"}}
     </h4>
     <p>
       <a href="itpc://datafruits.streampusher.com/podcasts/datafruits.xml">
-        iTunes
+        {{t "home.podcasts.link_itunes"}}
       </a>
       <a href="overcast://datafruits.streampusher.com/podcasts/datafruits.xml">
-        Overcast
+        {{t "home.podcasts.link_overcast"}}
       </a>
       <a href="podcast://datafruits.streampusher.com/podcasts/datafruits.xml">
-        Podcasts.app
+        {{t "home.podcasts.link_podcastsapp"}}
       </a>
       <a href="https://datafruits.streampusher.com/podcasts/datafruits.xml">
-        RSS
+        {{t "home.podcasts.link_rss"}}
       </a>
     </p>
     <PodcastsSearch

--- a/app/templates/home/show.hbs
+++ b/app/templates/home/show.hbs
@@ -4,7 +4,7 @@
     {{model.title}}
   </h1>
   <h2>
-    Hosted by:
+    {{t "show.hosted_prefix"}}
     {{#each model.djs as |dj|}}
       <span class="dj-title">
         <LinkTo @route="home.dj" @model={{dj.username}}>
@@ -19,10 +19,10 @@
   <div class="modal-body">
     {{#if model.thumbImageUrl}}
       <div class="show-image">
-        <img src="{{model.thumbImageUrl}}" alt="{{model.title}}" />
+        <img src={{model.thumbImageUrl}} alt={{model.title}}>
       </div>
     {{else if model.host.imageMediumUrl}}
-      <img src="{{model.host.imageMediumUrl}}" alt="{{model.dj.username}}" />
+      <img src={{model.host.imageMediumUrl}} alt={{model.dj.username}}>
     {{/if}}
     <p>
       {{html-safe-string model.htmlDescription}}

--- a/app/templates/home/subscribe.hbs
+++ b/app/templates/home/subscribe.hbs
@@ -37,11 +37,13 @@
           <div
             class="response hide"
             id="mce-error-response"
-          ></div>
+          >
+          </div>
           <div
             class="response hide"
             id="mce-success-response"
-          ></div>
+          >
+          </div>
         </div>
       </form>
     </div>

--- a/app/templates/home/subscribe.hbs
+++ b/app/templates/home/subscribe.hbs
@@ -1,10 +1,10 @@
 {{title "Newsletter"}}
 <div class="main-content">
   <h4 class="modal-title" id="myModalLabel">
-    DATAFRUITS.FM NEWSLETTER
+    {{t "newsletter_modal.title"}}
   </h4>
   <div class="modal-body">
-    <!-- Begin MailChimp Signup Form -->
+    {{!-- Begin MailChimp Signup Form --}}
     <div id="mc_embed_signup">
       <form
         action="http://datafruits.us7.list-manage1.com/subscribe/post?u=ad4bf41fe569a0d8e513b3dea&amp;id=4ae348e50b"
@@ -21,33 +21,31 @@
           name="EMAIL"
           class="required email"
           id="mce-EMAIL"
-          placeholder="Email"
-        />
+          placeholder={{t "newsletter_modal.placeholder_email"}}
+        >
         <input
           type="submit"
           value="Subscribe"
           name="subscribe"
           id="mc-embedded-subscribe"
           class="cool-button"
-        />
+        >
         <span class="tiny">
-          (Free exclusive tracks, mixes & info)
+          {{t "newsletter_modal.tiny"}}
         </span>
         <div id="mce-responses">
           <div
-            class="response"
+            class="response hide"
             id="mce-error-response"
-            style="display:none"
           ></div>
           <div
-            class="response"
+            class="response hide"
             id="mce-success-response"
-            style="display:none"
           ></div>
         </div>
       </form>
     </div>
-    <!--End mc_embed_signup-->
+    {{!--End mc_embed_signup--}}
   </div>
   <div class="modal-footer"></div>
 </div>

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,14 +1,14 @@
 <div id="not-found">
   <div id="not-found-spin">
     <h1>
-      404!
+      {{t "404.title"}}
     </h1>
-    <img src="{{random-loading-spinner}}" />
+    <img src={{random-loading-spinner}} alt={{t "loading"}}>
   </div>
   <h1>
-    Page not found
+    {{t "404.message"}}
   </h1>
   <LinkTo @route="home">
-    back to safety
+    {{t "404.return_linktext"}}
   </LinkTo>
 </div>


### PR DESCRIPTION
Assisting in getting closer to green builds again <3

```bash
yarn lint:hbs
```

## Before: 
<img width="413" alt="Screen Shot 2020-01-23 at 10 00 55 PM" src="https://user-images.githubusercontent.com/1664093/73043694-e8e41900-3e2b-11ea-8a60-8026155af52d.png">

## After:
<img width="264" alt="Screen Shot 2020-01-23 at 9 58 53 PM" src="https://user-images.githubusercontent.com/1664093/73043701-ebdf0980-3e2b-11ea-87fb-2b24629b6429.png">

---

## How to QA this

This touches a ton of files. The best things to QA are localized text strings because while I did try to be careful, I did move well over a hundred bits of localized text by hand to the english translations file. Look for "Missing loc" or whatever it says throughout the site - especially on text heavy pages like CoC and About.
