### PR TITLE
Removing old node restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,6 @@
     "textcomplete": "^0.17.1",
     "video.js": "7.2.4"
   },
-  "engines": {
-    "node": "10.x"
-  },
   "private": true,
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",


### PR DESCRIPTION
I initially had trouble fetching dependencies due to having too new of a Node version (LTS is beyond what is specified in the package.json's `engine` restriction.

Any objections to removing this restriction? Or at least bumping it to Node LTS `12.x`. I'm unsure of the history behind this project though and what servers it runs on etc.