### PR TITLE
Modify pagination on podcasts page

### DIFF
--- a/app/components/pagination.hbs
+++ b/app/components/pagination.hbs
@@ -8,17 +8,25 @@
     </LinkTo>
   </span>
 {{/if}}
+
 {{#each (range 1 (inc @meta.total_pages)) as |number|}}
-  {{#if (eq number @meta.page)}}
-    {{number}}
-  {{else}}
-    <span class="pagination">
-      <LinkTo @route={{@route}} @query={{hash page=number}}>
-        {{number}}
-      </LinkTo>
-    </span>
+  {{#if (or (and (lte number (inc 4 @meta.page))
+                 (gte number (dec 5 @meta.page)))
+            (and (lte @meta.page 5) (lte number 10))
+            (and (gt @meta.page (dec 4 @meta.total_pages))
+                 (gte number (dec 9 @meta.total_pages))))}}
+        {{#if (eq number @meta.page)}}
+          {{number}}
+        {{else}}
+          <span class="pagination">
+            <LinkTo @route={{@route}} @query={{hash page=number}}>
+              {{number}}
+            </LinkTo>
+          </span>
+        {{/if}}
   {{/if}}
 {{/each}}
+
 {{#if (lt @meta.page @meta.total_pages)}}
   <span class="pagination">
     <LinkTo


### PR DESCRIPTION
Hello, 
I did some work on https://github.com/datafruits/datafruits/issues/418.
It's slightly different from what's described in the issue. It works in a way similar to what google does with their search result pagination.

![pagination](https://user-images.githubusercontent.com/17218080/83496767-6967f580-a46e-11ea-91b1-b634f48f984c.png)
