### PR TITLE
teardown player on retryplaylist event

### DIFF
--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -77,9 +77,7 @@ export default class VideoStreamService extends Service {
 
   }
 
-  errorHandler(event) {
-    console.log('retryplaylist handler:');
-    console.log(event);
+  errorHandler(/*event*/) {
     this.set("active", false);
     this.get("player").dispose();
     this.set("player", null);

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -58,6 +58,8 @@ export default class VideoStreamService extends Service {
 
       player.userActive(false);
 
+      player.tech().on('retryplaylist', this.errorHandler.bind(this));
+
       let promise = player.play();
 
       if (promise !== undefined) {
@@ -73,6 +75,14 @@ export default class VideoStreamService extends Service {
       }
     });
 
+  }
+
+  errorHandler(event) {
+    console.log('retryplaylist handler:');
+    console.log(event);
+    this.set("active", false);
+    this.get("player").dispose();
+    this.set("player", null);
   }
 
   play() {


### PR DESCRIPTION
I tried to accomplish this with tracked properties in https://github.com/datafruits/datafruits/pull/413,
but I couldn't get it to work so I am doing it just using `set` here.