### PR TITLE
debounce hiding vol control

### DIFF
--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -2,6 +2,7 @@ import classic from 'ember-classic-decorator';
 import { classNameBindings } from '@ember-decorators/component';
 import { action, computed } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { debounce } from '@ember/runloop';
 import Component from '@ember/component';
 import { isEmpty } from '@ember/utils';
 
@@ -140,6 +141,20 @@ export default class DatafruitsPlayer extends Component {
   @action
   toggleVolumeControl() {
     this.toggleProperty('showingVolumeControl');
+  }
+
+  @action
+  showVolumeControl() {
+    this.set('showingVolumeControl', true);
+  }
+
+  @action
+  hideVolumeControl() {
+    debounce(this, this._hideVolumeControl, 2500);
+  }
+
+  _hideVolumeControl() {
+    this.set('showingVolumeControl', false);
   }
 
   @action

--- a/app/templates/components/datafruits-player.hbs
+++ b/app/templates/components/datafruits-player.hbs
@@ -35,7 +35,7 @@
         {{t "player.play"}}
       </a>
     {{/if}}
-    <span {{action "toggleVolumeControl" on="mouseEnter"}} {{action "toggleVolumeControl" on="mouseLeave"}}
+    <span {{action "showVolumeControl" on="mouseEnter"}} {{action "hideVolumeControl" on="mouseLeave"}}
       class="jp-volume-controls"
       role="button"
     >


### PR DESCRIPTION
Its set pretty high to delay hiding the control (2500 ms) but I think I
like this way, seems much easier to use.

Still needs to be fixed on mobile/touch devices....

![vol_fixed](https://user-images.githubusercontent.com/66243/90821757-48ce6f80-e2e8-11ea-970c-784c686b3135.gif)
