### PR TITLE
Fix issue with videojs

### DIFF
--- a/app/templates/components/datafruits-visuals.hbs
+++ b/app/templates/components/datafruits-visuals.hbs
@@ -1,9 +1,8 @@
 {{#if videoStreamActive}}
   <video
     id="video-player"
-    class="video-js vjs-default-skin vjs-16-9 vjs-big-play-centered"
+    class="video-js vjs-default-skin vjs-16-9 vjs-big-play-centered vjs-fluid"
     preload="auto"
-    data-setup="{'fluid': true}"
     playsinline
     muted
   >


### PR DESCRIPTION
Closes #496 

I don't know if this is actually the problem with the video, but it gets rid of the error message. Looking at the [source code](https://github.com/videojs/video.js/blob/master/src/js/player.js#L4668-L4716), there's this part:

```js
    if (Dom.hasClass(tag, 'vjs-fluid')) {
      tagOptions.fluid = true;
    }
```

Since all we were doing was trying to set `tagOptions.fluid` to `true` anyway, I just got rid of the `data-setup` tag entirely and applied the `vjs-fluid` class. I decided not to bother with trying to put valid json inside an html attribute, because i suspect that would be a headache.