### PR TITLE
use hostedBy string field for dj, instead of just loading the whole resource

### DIFF
--- a/app/models/scheduled-show.js
+++ b/app/models/scheduled-show.js
@@ -23,6 +23,9 @@ export default class ScheduledShow extends Model {
   @attr()
   description;
 
+  @attr()
+  hostedBy;
+
   @hasMany('track')
   tracks;
 

--- a/app/templates/home/dj.hbs
+++ b/app/templates/home/dj.hbs
@@ -14,7 +14,7 @@
     </h2>
     {{#if model.nextShow}}
       <LinkTo @route="home.show" @model={{model.nextShow}}>
-        {{model.nextShow.title}}
+        {{model.nextShow.title}} - {{format-date model.nextShow.start}}
       </LinkTo>
     {{/if}}
   </div>

--- a/app/templates/home/show.hbs
+++ b/app/templates/home/show.hbs
@@ -4,13 +4,11 @@
 </h1>
 <h2>
   {{t "show.hosted_prefix"}}
-  {{#each model.djs as |dj|}}
-    <span class="font-debussy text-xl">
-      <LinkTo @route="home.dj" @model={{dj.username}}>
-        {{dj.username}}
-      </LinkTo>
-    </span>
-  {{/each}}
+  <span class="font-debussy text-xl">
+    <LinkTo @route="home.dj" @model={{model.hostedBy}}>
+      {{model.hostedBy}}
+    </LinkTo>
+  </span>
 </h2>
 <h3 class="modal-title" id="myModalLabel">
   {{format-date model.start}}


### PR DESCRIPTION
Trying to cut down on async requests.