### PR TITLE
move datafruits to the bottom

### DIFF
--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -29,9 +29,6 @@
   <div class="overflow-auto min-h-0 text-white text-shadow flex flex-col flex-grow ">
     {{outlet}}
   </div>
-  <div class="flex-row flex justify-between text-xl classic:bg-df-green blm:bg-black trans:bg-df-blue">
-    <AddDatafruit />
-  </div>
   <DatafruitsPlayer
     class="flex-col flex justify-center classic:bg-df-pink blm:bg-black trans:bg-df-blue text-xl py-2 text-white leading-none"
     >
@@ -48,6 +45,9 @@
       />
     </div>
   </DatafruitsPlayer>
+  <div class="flex-row flex justify-between text-xl classic:bg-df-green blm:bg-black trans:bg-df-blue">
+    <AddDatafruit />
+  </div>
 </section>
 <DatafruitsVisuals
   class="block absolute top-0 w-screen h-screen h-handle-resize"


### PR DESCRIPTION
i think it looks a little better have the datafruits-ticker moved the absolute bottom, below the player, and the rest of the controls 📈📉📊🍇
![home page with datafruits ticker moved to bottom](https://user-images.githubusercontent.com/2829501/107114131-95bfe700-6831-11eb-958c-64639a70ff01.png)
