### PR TITLE
remove podcast-playing class

### DIFF
--- a/app/styles/player.scss
+++ b/app/styles/player.scss
@@ -10,15 +10,11 @@
 }
 
 div.radio-bar.is-live {
-  background-image: url("/assets/images/pink_sparkles.gif");
-}
-
-.playing-podcast {
-  background: $green !important;
+  background-image: url('/assets/images/pink_sparkles.gif');
 }
 
 div.radio-bar a:hover {
-  text-decoration:none;
+  text-decoration: none;
 }
 
 .jp-loading {
@@ -32,7 +28,8 @@ div.radio-bar a:hover {
   color: yellow;
 }
 
-.jp-play, .podcast-controls {
+.jp-play,
+.podcast-controls {
   display: inline-block;
   transition: all 0.25s ease-in-out;
   text-decoration: none;
@@ -46,15 +43,15 @@ div.radio-bar a:hover {
   display: flex;
   width: 100%;
   justify-content: center;
-  input[type=range] {
+  input[type='range'] {
     -webkit-appearance: none;
     margin: 18px 0;
     width: 100%;
   }
-  input[type=range]:focus {
+  input[type='range']:focus {
     outline: none;
   }
-  input[type=range]::-webkit-slider-runnable-track {
+  input[type='range']::-webkit-slider-runnable-track {
     width: 100%;
     height: 20px;
     cursor: pointer;
@@ -62,7 +59,7 @@ div.radio-bar a:hover {
     border-radius: 1.3px;
     border: none;
   }
-  input[type=range]::-webkit-slider-thumb {
+  input[type='range']::-webkit-slider-thumb {
     height: 25px;
     width: 25px;
     border-radius: 3px;
@@ -71,7 +68,7 @@ div.radio-bar a:hover {
     -webkit-appearance: none;
     margin-top: -2px;
   }
-  input[type=range]::-moz-range-track {
+  input[type='range']::-moz-range-track {
     width: 100%;
     height: 20px;
     cursor: pointer;
@@ -79,7 +76,7 @@ div.radio-bar a:hover {
     border-radius: 1.3px;
     border: none;
   }
-  input[type=range]::-moz-range-thumb {
+  input[type='range']::-moz-range-thumb {
     height: 25px;
     width: 25px;
     border-radius: 3px;
@@ -89,7 +86,7 @@ div.radio-bar a:hover {
     margin-top: -2px;
     border: none;
   }
-  input[type=range]::-ms-track {
+  input[type='range']::-ms-track {
     width: 100%;
     height: 20px;
     cursor: pointer;
@@ -97,15 +94,15 @@ div.radio-bar a:hover {
     border: none;
     color: transparent;
   }
-  input[type=range]::-ms-fill-lower {
+  input[type='range']::-ms-fill-lower {
     background: $pink;
     border-radius: 3px;
   }
-  input[type=range]::-ms-fill-upper {
+  input[type='range']::-ms-fill-upper {
     background: $pink;
     border-radius: 3px;
   }
-  input[type=range]::-ms-thumb {
+  input[type='range']::-ms-thumb {
     height: 25px;
     width: 25px;
     border-radius: 3px;
@@ -117,22 +114,22 @@ div.radio-bar a:hover {
     padding-left: 5px;
     padding-right: 17px;
     &.seeking {
-      input[type=range] {
+      input[type='range'] {
         border: none;
       }
-      input[type=range]::-webkit-slider-runnable-track {
+      input[type='range']::-webkit-slider-runnable-track {
         background: none;
         @include stripe-animation;
       }
-      input[type=range]::-moz-range-track {
+      input[type='range']::-moz-range-track {
         background: none;
         @include stripe-animation;
       }
-      input[type=range]::-ms-fill-lower {
+      input[type='range']::-ms-fill-lower {
         background: none;
         @include stripe-animation;
       }
-      input[type=range]::-ms-fill-upper {
+      input[type='range']::-ms-fill-upper {
         background: none;
         @include stripe-animation;
       }
@@ -158,23 +155,23 @@ div.radio-bar a:hover {
     top: -69px;
     left: -40px;
   }
-  input[type=range] {
+  input[type='range'] {
     -webkit-appearance: none;
     height: 100%;
     background: none;
     border: none;
   }
-  input[type=range]:focus {
+  input[type='range']:focus {
     outline: none;
   }
-  input[type=range]::-webkit-slider-runnable-track {
+  input[type='range']::-webkit-slider-runnable-track {
     height: 100%;
     width: 8.4px;
     cursor: pointer;
     background: $pink;
     border-radius: 5px;
   }
-  input[type=range]::-webkit-slider-thumb {
+  input[type='range']::-webkit-slider-thumb {
     height: 36px;
     width: 16px;
     border-radius: 5px;
@@ -183,24 +180,24 @@ div.radio-bar a:hover {
     -webkit-appearance: none;
     margin-top: -8px;
   }
-  input[type=range]:focus::-webkit-slider-runnable-track {
+  input[type='range']:focus::-webkit-slider-runnable-track {
     background: $pink;
   }
-  input[type=range]::-moz-range-track {
+  input[type='range']::-moz-range-track {
     height: 100%;
     width: 100%;
     cursor: pointer;
     background: $pink;
     border-radius: 5px;
   }
-  input[type=range]::-moz-range-thumb {
+  input[type='range']::-moz-range-thumb {
     height: 36px;
     width: 16px;
     border-radius: 5px;
     background: $yellow;
     cursor: pointer;
   }
-  input[type=range]::-ms-track {
+  input[type='range']::-ms-track {
     height: 100%;
     width: 100%;
     cursor: pointer;
@@ -209,25 +206,25 @@ div.radio-bar a:hover {
     border-width: 16px 0;
     color: transparent;
   }
-  input[type=range]::-ms-fill-lower {
+  input[type='range']::-ms-fill-lower {
     background: $pink;
     border-radius: 5px;
   }
-  input[type=range]::-ms-fill-upper {
+  input[type='range']::-ms-fill-upper {
     background: $pink;
     border-radius: 5px;
   }
-  input[type=range]::-ms-thumb {
+  input[type='range']::-ms-thumb {
     height: 36px;
     width: 16px;
     border-radius: 5px;
     background: $yellow;
     cursor: pointer;
   }
-  input[type=range]:focus::-ms-fill-lower {
+  input[type='range']:focus::-ms-fill-lower {
     background: $pink;
   }
-  input[type=range]:focus::-ms-fill-upper {
+  input[type='range']:focus::-ms-fill-upper {
     background: $pink;
   }
 }
@@ -238,14 +235,14 @@ audio {
 
 div.radio-bar {
   line-height: 1;
-  width:100%;
-  color:white;
-  text-decoration:none;
+  width: 100%;
+  color: white;
+  text-decoration: none;
   font-size: 25px;
   text-shadow: #333 1px 1px 1px;
   padding: 5px 0;
   @media only screen and (max-device-width: 480px) {
-    font-size:1.5rem;
+    font-size: 1.5rem;
     #next-show {
       display: none;
     }


### PR DESCRIPTION
This removes a CSS class meant for the podcast player. IDK if it makes sense to continue having this now that we have themes. We can make further modifications here to make the podcast-player distinct if needed.