### PR TITLE
fix some mobile display issues

### DIFF
--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -18,6 +18,7 @@
     {{else}}
       <LinkTo
         aria-label={{t "home.aria"}}
+        class="hidden md:block"
         @route="home.index">
         <h1 class="logo font-debussy text-5xl text-white">
           {{t "site_title_fm"}}
@@ -33,13 +34,13 @@
     class="flex-col flex justify-center classic:bg-df-pink blm:bg-black trans:bg-df-blue text-xl py-2 text-white leading-none"
     >
     <DjDonateButton class="hidden md:block mr-2" />
-    <div class="text-sm">
+    <div class="text-sm text-white hidden md:block">
       <ThemeSelector
-        class="text-white hidden md:block"
+        class="text-white"
         @setTheme={{action "setTheme"}}
       />
       <LocaleSelector
-        class="text-white hidden md:block mt-1"
+        class="text-white mt-1"
         @selectedLocale={{locale.value}}
         @setLocale={{action "setLocale"}}
       />


### PR DESCRIPTION
* hide theme selector on mobile
* fix hiding desktop logo on mobile

I'd like to add a "site settings" page somewhere, to allow mobile users to select language and theme. More settings/options can be moved there in the future if its crowding up the mobile view too much.

Next I'd like to clean up the chat login section at the bottom on mobile as its way too crowded, perhaps adding another modal.

![1619402614146](https://user-images.githubusercontent.com/66243/116019388-10551180-a67f-11eb-8461-0c826a206af5.png)
