### PR TITLE
replace cooltrash link with bandcamp merch page for now

### DIFF
--- a/app/templates/components/pc-nav.hbs
+++ b/app/templates/components/pc-nav.hbs
@@ -52,7 +52,7 @@
       <a
         class="text-white text-shadow-light hover:text-gray-400"
         aria-label={{t "shop.aria"}}
-        href="https://cooltrash.shop/" target="_blank" rel="noopener noreferrer">
+        href="https://datafruits.bandcamp.com/merch" target="_blank" rel="noopener noreferrer">
         {{t "shop.title"}}
       </a>
     </li>

--- a/app/templates/components/sp-nav.hbs
+++ b/app/templates/components/sp-nav.hbs
@@ -91,7 +91,7 @@
           <a
             class="text-white text-shadow-light"
             aria-label={{t "shop.title"}}
-            href="https://cooltrash.shop/" target="_blank" rel="noopener noreferrer">
+            href="https://datafruits.bandcamp.com/merch" target="_blank" rel="noopener noreferrer">
             {{t "shop.title"}}
           </a>
         </li>


### PR DESCRIPTION
While the new cooltrash.shop is under construction, change the shop link to the bandcamp merch page, there are at least a few items there.