### PR TITLE
fix chat scrolling bug

### DIFF
--- a/app/components/chat-messages.js
+++ b/app/components/chat-messages.js
@@ -2,8 +2,12 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 
 export default class ChatMessages extends Component {
+  @service
+  chat;
+
   @tracked willAutoscroll = false;
 
   _onScroll() {
@@ -24,7 +28,7 @@ export default class ChatMessages extends Component {
 
   @action
   setupAutoscroll() {
-    if (this.scrolledToBottom()) {
+    if (this.chat.isScrolledToBottom) {
       this.willAutoscroll = true;
     } else {
       this.args.newMessagesAvailable();
@@ -43,6 +47,7 @@ export default class ChatMessages extends Component {
   scrolledToBottom() {
     const messages = document.getElementById('messages');
     const messagesHeight = messages.getBoundingClientRect().height;
-    return messages.scrollHeight - messages.scrollTop - messagesHeight < 1;
+    const result = messages.scrollHeight - messages.scrollTop - messagesHeight < 1;
+    return result;
   }
 }

--- a/app/components/datafruits-chat.js
+++ b/app/components/datafruits-chat.js
@@ -49,15 +49,17 @@ export default class DatafruitsChat extends Component {
 
   @action
   onScroll() {
-    if (this.scrolledToBottom()) {
+    if (this.checkScrolledToBottom()) {
+      this.chat.isScrolledToBottom = true;
       this.newMessagesBelow = false;
     } else {
+      this.chat.isScrolledToBottom = false;
       this.newMessagesBelow = true;
     }
     this.chat.scrollTop = document.getElementById('messages').scrollTop;
   }
 
-  scrolledToBottom() {
+  checkScrolledToBottom() {
     const messages = document.getElementById('messages');
     const messagesHeight = messages.getBoundingClientRect().height;
     return messages.scrollHeight - messages.scrollTop - messagesHeight < 1;

--- a/app/services/chat.js
+++ b/app/services/chat.js
@@ -14,6 +14,8 @@ export default class ChatService extends Service {
   @tracked gifsEnabled = true;
   @tracked token = '';
 
+  @tracked isScrolledToBottom = true;
+
   join(username, token) {
     this.joinedChat = true;
     this.username = username;


### PR DESCRIPTION
We relied on the timing of `willRender` before, this no longer exists in new Ember versions.
We switched to a `did-insert` modifier, but by the time that code runs the new message is already inserted, so the way we checked if you were scrolled to the bottom doesn't work.

I am now storing the variable `isScrolledToBottom` in the chat service. It's updated when you scroll the chat.

https://github.com/emberjs/ember-render-modifiers/issues/38#issuecomment-895968119