### PR TITLE
authorize user again for chat

### DIFF
--- a/app/controllers/home/chat.js
+++ b/app/controllers/home/chat.js
@@ -37,8 +37,8 @@ export default class ChatController extends Controller {
           this.chat.push('authorize_token', {
             user: nick,
             timestamp: Date.now(),
-            token: token,
-            avatarUrl: avatarUrl,
+            token,
+            avatarUrl,
             role,
             style,
             pronouns,

--- a/app/services/chat.js
+++ b/app/services/chat.js
@@ -22,6 +22,26 @@ export default class ChatService extends Service {
     this.token = token;
   }
 
+  join_and_authorize(user, token) {
+    this.joinedChat = true;
+    this.username = user.username;
+    this.token = token;
+
+    const avatarUrl = user.avatarUrl;
+    const role = user.role;
+    const style = user.style;
+    const pronouns = user.pronouns;
+    this.push('authorize_token', {
+      user: user.username,
+      timestamp: Date.now(),
+      token: token,
+      avatarUrl,
+      role,
+      style,
+      pronouns,
+    });
+  }
+
   disconnect() {
     // need to broadcast a disconnect here or it will look like user is still in the chat to everyone
     this.chan.push('disconnect', { user: this.username });
@@ -35,10 +55,6 @@ export default class ChatService extends Service {
   constructor() {
     super(...arguments);
 
-    if (this.session.isAuthenticated && this.currentUser.user) {
-      this.join(this.currentUser.user.username, this.session.data.authenticated.token);
-    }
-
     let socket = this.socket.socket;
 
     this.chan = socket.channel('rooms:lobby', {});
@@ -48,7 +64,10 @@ export default class ChatService extends Service {
       .receive('ignore', function () {
         //return console.log("auth error");
       })
-      .receive('ok', function () {
+      .receive('ok', () => {
+        if (this.session.isAuthenticated && this.currentUser.user) {
+          this.join_and_authorize(this.currentUser.user, this.session.data.authenticated.token);
+        }
         return console.log('chat join ok'); // eslint-disable-line no-console
       })
       .receive('timeout', function () {


### PR DESCRIPTION
If they rejoin the chat with an existing token, send the authorize_token
msg to the channel again.

This will ensure the Presences (chat userlist) stays synced on the
Phoenix side.