### PR TITLE
mark scroll event listeners as passive

### DIFF
--- a/app/components/chat-messages.js
+++ b/app/components/chat-messages.js
@@ -16,8 +16,8 @@ export default class ChatMessages extends Component {
 
   @action
   addListener(element) {
-    element.addEventListener('scroll', this._onScroll.bind(this));
-    element.addEventListener('touchmove', this._onScroll.bind(this));
+    element.addEventListener('scroll', this._onScroll.bind(this), { passive: true });
+    element.addEventListener('touchmove', this._onScroll.bind(this), { passive: true });
   }
 
   @action


### PR DESCRIPTION
This should make the warnings in chrome/lighthouse go away.

reference: https://web.dev/uses-passive-event-listeners/?utm_source=lighthouse&utm_medium=devtools#how-to-make-event-listeners-passive-to-improve-scrolling-performance