### PR TITLE
set now playing metadata in page title

### DIFF
--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -56,7 +56,6 @@ export default class DatafruitsPlayer extends Component {
   }
 
   setPageTitle(){
-    console.log('in setPageTitle');
     if (!this.fastboot.isFastBoot) {
       document.title = `DATAFRUITS.FM - ${this.title}`;
     }

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -55,15 +55,24 @@ export default class DatafruitsPlayer extends Component {
     return !isEmpty(title) && title.startsWith('LIVE');
   }
 
+  setPageTitle(){
+    console.log('in setPageTitle');
+    if (!this.fastboot.isFastBoot) {
+      document.title = `DATAFRUITS.FM - ${this.title}`;
+    }
+  }
+
   setRadioTitle() {
     if (this.playingPodcast === false) {
       this.title = this.metadata.title;
     }
+    this.setPageTitle();
   }
 
   onTrackPlayed(track) {
     this.error = null;
     this.title = track.title;
+    this.setPageTitle();
     this.playingPodcast = true;
     this.playTime = 0.0;
 

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -55,7 +55,7 @@ export default class DatafruitsPlayer extends Component {
     return !isEmpty(title) && title.startsWith('LIVE');
   }
 
-  setPageTitle(){
+  setPageTitle() {
     if (!this.fastboot.isFastBoot) {
       document.title = `DATAFRUITS.FM - ${this.title}`;
     }

--- a/app/services/page-title.js
+++ b/app/services/page-title.js
@@ -1,0 +1,11 @@
+import { inject as service } from '@ember/service';
+import EmberPageTitleService from 'ember-page-title/services/page-title';
+
+export default class PageTitleService extends EmberPageTitleService {
+  @service
+  metadata;
+
+  titleDidUpdate(title) {
+    document.title = `${title} - ${this.metadata.title}`;
+  }
+}


### PR DESCRIPTION
This can help improve the experience on mobile, as your lock screen will
show the page title so you know what you are listening to on datafruits.