### PR TITLE
use video's audio when /live viz endpoint is active

### DIFF
--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -87,21 +87,16 @@ export default class DatafruitsPlayer extends Component {
   useVideoAudio() {
     this.error = null;
     this.videoAudioOn = true;
-    // what to use for title??????
-    //this.title = track.title;
-    //this.setPageTitle();
 
     let audioTag = document.getElementById('radio-player');
     audioTag.muted = true;
-    //unmute video's audio
     this.videoStream.unmute();
   }
 
   disableVideoAudio() {
-    console.log('disabling video audio');
     this.videoAudioOn = false;
     let audioTag = document.getElementById('radio-player');
-    audioTag.muted = true;
+    audioTag.muted = false;
   }
 
   @action

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -177,8 +177,12 @@ export default class DatafruitsPlayer extends Component {
   volumeChanged(e) {
     this.volume = e.target.value;
     localStorage.setItem('datafruits-volume', this.volume);
-    let audioTag = document.getElementById('radio-player');
-    audioTag.volume = this.volume;
+    if (this.videoAudioOn) {
+      this.videoStream.setVolume(this.volume);
+    } else {
+      let audioTag = document.getElementById('radio-player');
+      audioTag.volume = this.volume;
+    }
   }
 
   @action

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -135,7 +135,7 @@ export default class DatafruitsPlayer extends Component {
 
   @action
   pause() {
-    if(this.videoAudioOn) {
+    if (this.videoAudioOn) {
       this.videoStream.mute();
     } else {
       let audioTag = document.getElementById('radio-player');

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -47,6 +47,7 @@ export default class DatafruitsPlayer extends Component {
     this.eventBus.subscribe('trackPlayed', this, 'onTrackPlayed');
     this.eventBus.subscribe('metadataUpdate', this, 'setRadioTitle');
     this.eventBus.subscribe('liveVideoAudio', this, 'useVideoAudio');
+    this.eventBus.subscribe('liveVideoAudioOff', this, 'disableVideoAudio');
 
     if (!this.fastboot.isFastBoot) {
       this.volume = localStorage.getItem('datafruits-volume') || 0.8;
@@ -96,6 +97,13 @@ export default class DatafruitsPlayer extends Component {
     this.videoStream.unmute();
   }
 
+  disableVideoAudio() {
+    console.log('disabling video audio');
+    this.videoAudioOn = false;
+    let audioTag = document.getElementById('radio-player');
+    audioTag.muted = true;
+  }
+
   @action
   playButtonMouseEnter() {
     this.playButtonHover = true;
@@ -132,16 +140,24 @@ export default class DatafruitsPlayer extends Component {
 
   @action
   pause() {
-    let audioTag = document.getElementById('radio-player');
-    audioTag.pause();
+    if(this.videoAudioOn) {
+      this.videoStream.mute();
+    } else {
+      let audioTag = document.getElementById('radio-player');
+      audioTag.pause();
+    }
     this.playButtonPressed = false;
     this.playerState = 'paused';
   }
 
   @action
   mute() {
-    let audioTag = document.getElementById('radio-player');
-    audioTag.muted = true;
+    if (this.videoAudioOn) {
+      this.videoStream.mute();
+    } else {
+      let audioTag = document.getElementById('radio-player');
+      audioTag.muted = true;
+    }
     this.muted = true;
     this.oldVolume = this.volume;
     this.volume = 0.0;
@@ -150,8 +166,12 @@ export default class DatafruitsPlayer extends Component {
 
   @action
   unmute() {
-    let audioTag = document.getElementById('radio-player');
-    audioTag.muted = false;
+    if (this.videoAudioOn) {
+      this.videoStream.unmute();
+    } else {
+      let audioTag = document.getElementById('radio-player');
+      audioTag.muted = false;
+    }
     this.muted = false;
     this.volume = this.oldVolume;
     localStorage.setItem('datafruits-volume', this.volume);

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -91,7 +91,7 @@ export default class DatafruitsPlayer extends Component {
     //this.setPageTitle();
 
     let audioTag = document.getElementById('radio-player');
-    audioTag.mute();
+    audioTag.muted = true;
     //unmute video's audio
     this.videoStream.unmute();
   }

--- a/app/components/datafruits-player.js
+++ b/app/components/datafruits-player.js
@@ -28,6 +28,7 @@ export default class DatafruitsPlayer extends Component {
   @tracked oldVolume = 0.8;
   @tracked playTime = 0.0;
   @tracked volume = 1.0;
+  @tracked videoAudioOn = false;
 
   get paused() {
     return this.playerState === 'paused';
@@ -45,6 +46,8 @@ export default class DatafruitsPlayer extends Component {
     super(...arguments);
     this.eventBus.subscribe('trackPlayed', this, 'onTrackPlayed');
     this.eventBus.subscribe('metadataUpdate', this, 'setRadioTitle');
+    this.eventBus.subscribe('liveVideoAudio', this, 'useVideoAudio');
+
     if (!this.fastboot.isFastBoot) {
       this.volume = localStorage.getItem('datafruits-volume') || 0.8;
     }
@@ -78,6 +81,19 @@ export default class DatafruitsPlayer extends Component {
     let audioTag = document.getElementById('radio-player');
     audioTag.src = track.cdnUrl;
     audioTag.play();
+  }
+
+  useVideoAudio() {
+    this.error = null;
+    this.videoAudioOn = true;
+    // what to use for title??????
+    //this.title = track.title;
+    //this.setPageTitle();
+
+    let audioTag = document.getElementById('radio-player');
+    audioTag.mute();
+    //unmute video's audio
+    this.videoStream.unmute();
   }
 
   @action

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -89,7 +89,7 @@ export default class VideoStreamService extends Service {
     this.player = null;
     this.useVideoAudio = false;
     this.eventBus.publish('liveVideoAudioOff');
-
+    later(() => {
       this.fetchStream();
     }, 1000);
   }

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -66,7 +66,7 @@ export default class VideoStreamService extends Service {
         promise
           .then(() => {
             console.log('video autoplayed'); // eslint-disable-line no-console
-            if(this.useVideoAudio) {
+            if (this.useVideoAudio) {
               this.eventBus.publish('liveVideoAudio');
             }
             player.userActive(false);
@@ -75,7 +75,7 @@ export default class VideoStreamService extends Service {
             // Autoplay was prevented.
             console.log(`video autoplay failed: ${error}`); // eslint-disable-line no-console
             player.userActive(false);
-            //this.rollbar.error(`video autoplay failed: ${error}`);
+            this.rollbar.error(`video autoplay failed: ${error}`);
           });
       }
     });
@@ -89,7 +89,7 @@ export default class VideoStreamService extends Service {
     this.player = null;
     this.useVideoAudio = false;
     this.eventBus.publish('liveVideoAudioOff');
-    later(() => {
+
       this.fetchStream();
     }, 1000);
   }
@@ -102,7 +102,7 @@ export default class VideoStreamService extends Service {
         promise
           .then(() => {
             console.log('video played'); // eslint-disable-line no-console
-            if(this.useVideoAudio) {
+            if (this.useVideoAudio) {
               this.eventBus.publish('liveVideoAudio');
             }
             player.userActive(false);
@@ -111,7 +111,7 @@ export default class VideoStreamService extends Service {
             // Autoplay was prevented.
             console.log(`video play failed: ${error}`); // eslint-disable-line no-console
             player.userActive(false);
-            //this.rollbar.error(`video autoplay failed: ${error}`);
+            this.rollbar.error(`video autoplay failed: ${error}`);
           });
       }
     } else {

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -89,6 +89,9 @@ export default class VideoStreamService extends Service {
     this.player = null;
     this.useVideoAudio = false;
     this.eventBus.publish('liveVideoAudioOff');
+    later(() => {
+      this.fetchStream();
+    }, 1000);
   }
 
   play() {

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -8,6 +8,9 @@ export default class VideoStreamService extends Service {
   @service
   rollbar;
 
+  @service
+  eventBus;
+
   constructor() {
     super(...arguments);
     this.streamHost = ENV.STREAM_HOST;
@@ -101,6 +104,10 @@ export default class VideoStreamService extends Service {
     }
   }
 
+  unmute() {
+    this.player.unmute(); // >>>???
+  }
+
   streamIsActive(name, extension) {
     this.active = true;
     this.streamName = name;
@@ -115,13 +122,15 @@ export default class VideoStreamService extends Service {
         if (response.status == 200) {
           this.streamIsActive(`${name}`, 'm3u8');
         } else {
-          //no m3u8 exists, try vod file
-
-          fetch(`${host}/hls/${name}.mp4`, { method: 'HEAD' })
+          //
+          // fetch /live here
+          fetch(`${host}/live/${name}.mp4`, { method: 'HEAD' })
             .then((response) => {
               if (response.status == 200) {
                 //mp4 exists, play it
                 this.streamIsActive(name, 'mp4');
+                // send some event bus event about /live being .... live
+                this.eventBus.publish('liveVideoAudio');
               } else {
                 if (ENV.environment === 'test') return;
                 console.log('No stream found'); // eslint-disable-line no-console

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -18,6 +18,7 @@ export default class VideoStreamService extends Service {
   }
 
   @tracked active = false;
+  @tracked useVideoAudio = false;
 
   async initializePlayer() {
     const module = await import('video.js');
@@ -65,8 +66,9 @@ export default class VideoStreamService extends Service {
         promise
           .then(() => {
             console.log('video autoplayed'); // eslint-disable-line no-console
-            // send some event bus event about /live being .... live
-            this.eventBus.publish('liveVideoAudio');
+            if(this.useVideoAudio) {
+              this.eventBus.publish('liveVideoAudio');
+            }
             player.userActive(false);
           })
           .catch((error) => {
@@ -79,10 +81,14 @@ export default class VideoStreamService extends Service {
     });
   }
 
-  errorHandler(/*event*/) {
+  errorHandler(event) {
+    console.log('in errorHandler');
+    console.log(event);
     this.active = false;
     this.player.dispose();
     this.player = null;
+    this.useVideoAudio = false;
+    this.eventBus.publish('liveVideoAudioOff');
   }
 
   play() {
@@ -93,8 +99,9 @@ export default class VideoStreamService extends Service {
         promise
           .then(() => {
             console.log('video played'); // eslint-disable-line no-console
-            // send some event bus event about /live being .... live
-            this.eventBus.publish('liveVideoAudio');
+            if(this.useVideoAudio) {
+              this.eventBus.publish('liveVideoAudio');
+            }
             player.userActive(false);
           })
           .catch((error) => {
@@ -113,6 +120,10 @@ export default class VideoStreamService extends Service {
     this.player.muted(false);
   }
 
+  mute() {
+    this.player.muted(true);
+  }
+
   setVolume(vol) {
     this.player.volume(vol);
   }
@@ -122,6 +133,9 @@ export default class VideoStreamService extends Service {
     this.streamName = name;
     this.extension = extension;
     this.path = path;
+    if (path === 'live') {
+      this.useVideoAudio = true;
+    }
   }
 
   fetchStream() {

--- a/app/services/video-stream.js
+++ b/app/services/video-stream.js
@@ -110,7 +110,11 @@ export default class VideoStreamService extends Service {
   }
 
   unmute() {
-    this.player.muted(false); // >>>???
+    this.player.muted(false);
+  }
+
+  setVolume(vol) {
+    this.player.volume(vol);
   }
 
   streamIsActive(name, extension, path) {


### PR DESCRIPTION
-  [x] play video's audio if /live is active
- [x] make the vol control work for the video audio
- [x] make mute/unmute button work for the video audio
- [ ] metadata?
- [ ] auth?
- [x] handle disconnection of /live