### PR TITLE
link to coc encforcement doc on coc page

### DIFF
--- a/app/templates/home/coc.hbs
+++ b/app/templates/home/coc.hbs
@@ -78,6 +78,12 @@
     <p>
       {{t "coc.enforcement.p2"}}
     </p>
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://docs.google.com/document/d/1H7j23zdNpZcLUJvMBpzPl7FcIYFrjJ9CLGKEI16an4Y/edit?usp=sharing">
+      {{t "coc.enforcement.policy"}}
+    </a>
     <h1>
       {{t "coc.attribution.title"}}
     </h1>

--- a/translations/en.json
+++ b/translations/en.json
@@ -294,7 +294,8 @@
       "p1_part1": "Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the datafruits administrators (email",
       "p1_part2": "). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.",
       "p1_linktext": "info@datafruits.fm",
-      "p2": "Datafruits administrators who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership."
+      "p2": "Datafruits administrators who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.",
+      "policy": "CoC Enforcement Policy"
     },
     "attribution": {
       "title": "Attribution",


### PR DESCRIPTION
This links to the google doc on how the CoC is enforced from the main CoC page.

Maybe this can be a wiki article later when we implement the wiki.
