### PR TITLE
Missing social media icons in About page

### DIFF
--- a/app/templates/home/about.hbs
+++ b/app/templates/home/about.hbs
@@ -40,18 +40,18 @@
             {{t "about_page.listenersupport"}}
           </p>
           <div>
-            <a href="https://www.ampled.com/artist/datafruits" target="_blank" rel="noopener" aria-label={{t "patron_aria"}}>
-              {{t "patron.title"}}
+            <a href="https://www.ampled.com/artist/datafruits" target="_blank" rel="noopener noreferrer" aria-label="Ampled">
+              <img src="/assets/images/ampled.svg" aria-hidden="true" class="md:w-72">
             </a>
           </div>
-          <div>
-            <p>
-              {{t "about_page.donate_request"}}
-            </p>
-            <a href="https://paypal.me/datafruitsfm" target="_blank" rel="noopener" aria-label={{t "about_page.donate_aria"}}>
-              {{t "about_page.donate_linktext"}}
-            </a>
-          </div>
+        </div>
+        <div class="about-section">
+          <p>
+            {{t "about_page.donate_request"}}
+          </p>
+          <a href="https://paypal.me/datafruitsfm" target="_blank" rel="noopener" aria-label={{t "about_page.donate_aria"}}>
+            {{t "about_page.donate_linktext"}}
+          </a>
         </div>
       </div>
       <div id="subscribe-details">
@@ -65,13 +65,13 @@
         </LinkTo>
         </div>
       </div>
-      <hr class="border-df-green blm:border-white"/>
-      <div id="social-media-links" class="text-4xl">
+      <hr class="border-df-green my-4 blm:border-white"/>
+      <div id="social-media-links" class="text-4xl py-2">
         <ul class="flex flex-wrap mb-4 justify-evenly">
           <li>
             <a
               href="https://discord.gg/83mteTQDvu"
-              title={{t "discord"}}
+              title={{t "discord.title"}}
               aria-label={{t "discord.aria"}}
               target="_blank"
               rel="noopener"
@@ -81,46 +81,24 @@
           </li>
           <li>
             <a
+              href="https://www.youtube.com/channel/UCYTXGeHBvKP0Q9Wcxfop5FA/"
+              title={{t "youtube.title"}}
+              aria-label={{t "youtube.aria"}}
+              target="_blank"
+              rel="noopener"
+            >
+              <FaIcon @icon="youtube" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a
               href="http://twitter.com/datafruits"
-              title={{t "twitter"}}
+              title={{t "twitter.title"}}
               aria-label={{t "twitter.aria"}}
               target="_blank"
               rel="noopener"
             >
               <FaIcon @icon="twitter" @prefix="fab" />
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://github.com/datafruits"
-              title={{t "github.title"}}
-              aria-label={{t "github.aria"}}
-              target="_blank"
-              rel="noopener"
-            >
-              <FaIcon @icon="github" @prefix="fab" />
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://soundcloud.com/datafruits"
-              title={{t "soundcloud.title"}}
-              aria-label={{t "soundcloud.aria"}}
-              target="_blank"
-              rel="noopener"
-            >
-              <FaIcon @icon="soundcloud" @prefix="fab" />
-            </a>
-          </li>
-          <li>
-            <a
-              href="http://mixcloud.com/datafruits"
-              title={{t "mixcloud.title"}}
-              aria-label={{t "mixcloud.aria"}}
-              target="_blank"
-              rel="noopener"
-            >
-              <FaIcon @icon="mixcloud" @prefix="fab" />
             </a>
           </li>
           <li>
@@ -136,13 +114,67 @@
           </li>
           <li>
             <a
-              href="https://www.youtube.com/channel/UCYTXGeHBvKP0Q9Wcxfop5FA/"
-              title={{t "youtube.title"}}
-              aria-label={{t "youtube.aria"}}
+              href="http://soundcloud.com/datafruits"
+              title={{t "soundcloud.title"}}
+              aria-label={{t "soundcloud.aria"}}
               target="_blank"
               rel="noopener"
             >
-              <FaIcon @icon="youtube" @prefix="fab" />
+              <FaIcon @icon="soundcloud" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a 
+              href="https://datafruits.bandcamp.com/"
+              title={{t "bandcamp.title"}}
+              aria-label={{t "bandcamp.aria"}}
+              target="_blank"
+              rel="noopener"
+            >
+              <FaIcon @icon="bandcamp" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a
+              href="http://mixcloud.com/datafruits"
+              title={{t "mixcloud.title"}}
+              aria-label={{t "mixcloud.aria"}}
+              target="_blank"
+              rel="noopener"
+            >
+              <FaIcon @icon="mixcloud" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a 
+              href="https://www.patreon.com/datafruits"
+              title={{t "patreon.title"}}
+              aria-label={{t "patreon.aria"}}
+              target="_blank"
+              rel="noopener"
+            >
+              <FaIcon @icon="patreon" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a
+              href="http://github.com/datafruits"
+              title={{t "github.title"}}
+              aria-label={{t "github.aria"}}
+              target="_blank"
+              rel="noopener"
+            >
+              <FaIcon @icon="github" @prefix="fab" />
+            </a>
+          </li>
+          <li>
+            <a href="https://paypal.me/datafruitsfm" 
+              title={{t "paypal.title"}}
+              target="_blank" 
+              rel="noopener" 
+              aria-label={{t "about_page.donate_aria"}}
+            >
+              <FaIcon @icon="paypal" @prefix="fab" />
             </a>
           </li>
           <li>

--- a/config/icons.js
+++ b/config/icons.js
@@ -11,6 +11,15 @@ module.exports = function () {
       'times',
       'heart',
     ],
-    'free-brands-svg-icons': ['twitter', 'instagram', 'github', 'twitter', 'soundcloud', 'mixcloud'],
+    'free-brands-svg-icons': [
+      'twitter', 
+      'instagram', 
+      'github', 
+      'twitter', 
+      'soundcloud', 
+      'mixcloud',
+      'discord', 
+      'youtube'
+    ],
   };
 };

--- a/config/icons.js
+++ b/config/icons.js
@@ -19,7 +19,10 @@ module.exports = function () {
       'soundcloud', 
       'mixcloud',
       'discord', 
-      'youtube'
+      'paypal',
+      'patreon',
+      'youtube',
+      'bandcamp',
     ],
   };
 };

--- a/translations/en.json
+++ b/translations/en.json
@@ -249,17 +249,33 @@
     "title": "Mixcloud",
     "aria": "Check out the datafruits Mixcloud page"
   },
+  "bandcamp": {
+    "title": "Bandcamp",
+    "aria": "Find releases on the datafruits label on Bandcamp"
+  },
+  "discord": {
+    "title": "Discord",
+    "aria": "Join the datafruits Discord"
+  },
+  "patreon": {
+    "title": "Patreon",
+    "aria": "Support datafruits through Patreon"
+  },
+  "paypal": {
+    "title": "Paypal",
+    "aria": "Donate to datafruits via Paypal"
+  },
   "instagram": {
     "title": "Instagram",
     "aria": "Browse posts from datafruits on Instagram"
   },
   "youtube": {
     "title": "Youtube",
-    "aria": "datafruits youtube channel"
+    "aria": "Watch the datafruits Youtube channel"
   },
   "email": {
     "title": "Email info@datafruits.fm",
-    "aria": "Notify datafruits by email"
+    "aria": "Message datafruits by email"
   },
   "patron": {
     "title": "Ampled",


### PR DESCRIPTION
The youtube and discord fa icons were missing and I was able to fix it by adding these names to the icon config. I also modified the subscription section of the about page to include the Ampled graphic. Oh yeah, and I reorganized the icons at the bottom. It seems like we should try to group them by category, but IDK, maybe there's a better way of displaying all of these.

![image](https://user-images.githubusercontent.com/2829501/210657638-5e878e6c-ca46-4948-9277-24d7fb0bba6e.png)
