### PR TITLE
show data urls and hide text

### DIFF
--- a/app/components/chat-message.hbs
+++ b/app/components/chat-message.hbs
@@ -47,20 +47,11 @@
 
 </li>
 {{#if @gifsEnabled}}
-  {{#if this.hasImage}}
+  {{#if (or this.hasImage this.hasData)}}
     <li class="message">
       <span class="">
         <ChatLazyImage
-          @url={{this.imgUrl}}
-          @adjustScrolling={{@adjustScrolling}}
-        />
-      </span>
-    </li>
-  {{else if this.hasData}}
-    <li class="message">
-      <span>
-        <ChatLazyImage
-          @url={{this.dataUrl}}
+          @url={{this.getImage}}
           @adjustScrolling={{@adjustScrolling}}
         />
       </span>

--- a/app/components/chat-message.hbs
+++ b/app/components/chat-message.hbs
@@ -28,7 +28,7 @@
       />
   </span>
   
-    {{#if this.fromDiscord}}
+  {{#if this.fromDiscord}}
     <a class="mr-2"
       href="https://discord.gg/83mteTQDvu"
       title={{t "chat.discord"}}
@@ -39,9 +39,12 @@
     </a>
   {{/if}}
 
-  <span class={{if @message.hasMention "bg-df-green-dark"}} data-test-message-body>
-    {{format-message-body (if this.fromDiscord this.discordMsg @message.body)}}
-  </span>
+  {{#unless (or this.hasImage this.hasData)}}
+    <span class={{if @message.hasMention "bg-df-green-dark"}} data-test-message-body>
+      {{format-message-body (if this.fromDiscord this.discordMsg @message.body)}}
+    </span>
+  {{/unless}}
+
 </li>
 {{#if @gifsEnabled}}
   {{#if this.hasImage}}
@@ -49,6 +52,15 @@
       <span class="">
         <ChatLazyImage
           @url={{this.imgUrl}}
+          @adjustScrolling={{@adjustScrolling}}
+        />
+      </span>
+    </li>
+  {{else if this.hasData}}
+    <li class="message">
+      <span>
+        <ChatLazyImage
+          @url={{this.dataUrl}}
           @adjustScrolling={{@adjustScrolling}}
         />
       </span>

--- a/app/components/chat-message.hbs
+++ b/app/components/chat-message.hbs
@@ -39,9 +39,9 @@
     </a>
   {{/if}}
 
-  {{#unless (or this.hasImage this.hasData)}}
+  {{#unless (this.hasImageData)}}
     <span class={{if @message.hasMention "bg-df-green-dark"}} data-test-message-body>
-      {{format-message-body (if this.fromDiscord this.discordMsg @message.body)}}
+      {{format-message-body (if this.fromDiscord this.discordMsg this.messageText)}}
     </span>
   {{/unless}}
 

--- a/app/components/chat-message.hbs
+++ b/app/components/chat-message.hbs
@@ -47,11 +47,11 @@
 
 </li>
 {{#if @gifsEnabled}}
-  {{#if (or this.hasImage this.hasData)}}
+  {{#if this.hasImageData}}
     <li class="message">
       <span class="">
         <ChatLazyImage
-          @url={{this.getImage}}
+          @url={{this.imgUrl}}
           @adjustScrolling={{@adjustScrolling}}
         />
       </span>

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -29,7 +29,7 @@ export default class ChatMessage extends Component {
   get hasImageData() {
     return this.hasImage || this.hasData;
   }
-  
+
   get imgUrl() {
     if (this.hasImage)
       return this.args.message.body.match(this.imgRegex)[0];
@@ -38,6 +38,19 @@ export default class ChatMessage extends Component {
       return this.args.message.body.match(this.dataRegex)[0];
 
     return ""
+  }
+  
+  get messageText() {
+    var body = this.args.message.body;
+
+    if (this.hasImage) {
+      body = this.args.message.body.replace(this.imgRegex, "");
+    }
+    if (this.hasData) {
+      body = this.args.message.body.replace(this.dataRegex, "");
+    }
+
+    return body;
   }
   
   get fromDiscord() {

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 export default class ChatMessage extends Component {
   @tracked gifsEnabled = true;
   @tracked imgRegex = /https?:\/\/(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpg|gif|png|webp)(\?.*$)*/;
-  @tracked dataRegex = /data:image\/png;base64,.+/;
+  @tracked dataRegex = /data:image\/(?:png|jpeg|webp);base64,.+/;
   @tracked discordRegex = /^New\ msg\ in\ discord\ from\ (.+):\ (.+)$/; // eslint-disable-line no-useless-escape
 
   get canShowAvatar() {
@@ -34,6 +34,13 @@ export default class ChatMessage extends Component {
     return this.args.message.body.match(this.dataRegex)[0];
   }
 
+  get getImage() {
+    if (this.hasImage) return this.imgUrl();
+    if (this.hasData) return this.dataUrl();
+
+    return null;
+  }
+  
   get fromDiscord() {
     return this.discordRegex.test(this.args.message.body) && this.args.message.user == "coach";
   }

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -5,6 +5,7 @@ import { action } from '@ember/object';
 export default class ChatMessage extends Component {
   @tracked gifsEnabled = true;
   @tracked imgRegex = /https?:\/\/(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpg|gif|png|webp)(\?.*$)*/;
+  @tracked dataRegex = /data:image\/png;base64,.+/;
   @tracked discordRegex = /^New\ msg\ in\ discord\ from\ (.+):\ (.+)$/; // eslint-disable-line no-useless-escape
 
   get canShowAvatar() {
@@ -21,8 +22,16 @@ export default class ChatMessage extends Component {
     return this.imgRegex.test(this.args.message.body);
   }
 
+  get hasData() {
+    return this.dataRegex.test(this.args.message.body);
+  }
+
   get imgUrl() {
     return this.args.message.body.match(this.imgRegex)[0];
+  }
+
+  get dataUrl() {
+    return this.args.message.body.match(this.dataRegex)[0];
   }
 
   get fromDiscord() {

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -5,7 +5,7 @@ import { action } from '@ember/object';
 export default class ChatMessage extends Component {
   @tracked gifsEnabled = true;
   @tracked imgRegex = /https?:\/\/(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpg|gif|png|webp)(\?.*$)*/;
-  @tracked dataRegex = /data:image\/(?:png|jpeg|webp);base64,.+/;
+  @tracked dataRegex = /data:image\/.+;base64,.+/;
   @tracked discordRegex = /^New\ msg\ in\ discord\ from\ (.+):\ (.+)$/; // eslint-disable-line no-useless-escape
 
   get canShowAvatar() {
@@ -26,19 +26,18 @@ export default class ChatMessage extends Component {
     return this.dataRegex.test(this.args.message.body);
   }
 
+  get hasImageData() {
+    return this.hasImage || this.hasData;
+  }
+  
   get imgUrl() {
-    return this.args.message.body.match(this.imgRegex)[0];
-  }
+    if (this.hasImage)
+      return this.args.message.body.match(this.imgRegex)[0];
 
-  get dataUrl() {
-    return this.args.message.body.match(this.dataRegex)[0];
-  }
+    if (this.hasData)
+      return this.args.message.body.match(this.dataRegex)[0];
 
-  get getImage() {
-    if (this.hasImage) return this.imgUrl();
-    if (this.hasData) return this.dataUrl();
-
-    return null;
+    return ""
   }
   
   get fromDiscord() {

--- a/app/components/chat-message.js
+++ b/app/components/chat-message.js
@@ -4,9 +4,9 @@ import { action } from '@ember/object';
 
 export default class ChatMessage extends Component {
   @tracked gifsEnabled = true;
-  @tracked imgRegex = /https?:\/\/(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpg|gif|png|webp)(\?.*$)*/;
-  @tracked dataRegex = /data:image\/.+;base64,.+/;
-  @tracked discordRegex = /^New\ msg\ in\ discord\ from\ (.+):\ (.+)$/; // eslint-disable-line no-useless-escape
+  imgRegex = /https?:\/\/(?:[a-z0-9-]+\.)+[a-z]{2,6}(?:\/[^/#?]+)+\.(?:jpg|gif|png|webp)(\?.*$)*/;
+  dataRegex = /data:image\/.+;base64,.+/;
+  discordRegex = /^New\ msg\ in\ discord\ from\ (.+):\ (.+)$/; // eslint-disable-line no-useless-escape
 
   get canShowAvatar() {
     if (!this.args.message.role) return false;
@@ -52,7 +52,7 @@ export default class ChatMessage extends Component {
 
     return body;
   }
-  
+
   get fromDiscord() {
     return this.discordRegex.test(this.args.message.body) && this.args.message.user == "coach";
   }

--- a/tests/integration/components/chat-message-test.js
+++ b/tests/integration/components/chat-message-test.js
@@ -35,7 +35,7 @@ module('Integration | Component | chat message', function (hooks) {
     await render(hbs`{{chat-message message=message setupAutoscroll=setupAutoscroll adjustScrolling=adjustScrolling}}`);
 
     assert.dom('[data-test-username]').hasText('tony');
-    assert.dom('[data-test-message-body]').hasText('hey a cat http://cat.com/cat.png');
+    assert.dom('[data-test-message-body]').hasText('hey a cat');
     assert.equal(this.element.querySelector('a').getAttribute('href'), 'http://cat.com/cat.png');
     assert.equal(this.element.querySelector('img').getAttribute('src'), 'http://cat.com/cat.png');
   });
@@ -56,8 +56,7 @@ module('Integration | Component | chat message', function (hooks) {
     );
 
     assert.dom('[data-test-username]').hasText('tony');
-    assert.dom('[data-test-message-body]').hasText('hey a cat http://cat.com/cat.png');
-    assert.equal(this.element.querySelector('a').getAttribute('href'), 'http://cat.com/cat.png');
+    assert.dom('[data-test-message-body]').hasText('hey a cat');
     assert.notOk(this.element.querySelector('img'));
   });
 });


### PR DESCRIPTION
here are two big burritos in one bag:
* doesn't show the URL when an image is posted
* handles the data URL format for base 64-encoded images

I tested the data URL handling locally and it worked with one exception. The regex to recognize the format was allowing any data type. I've refined it to handle a few image formats, but haven't tested that change yet