### PR TITLE
set clipboard data to base64 image

### DIFF
--- a/app/components/chat/input-message.hbs
+++ b/app/components/chat/input-message.hbs
@@ -11,6 +11,7 @@
       placeholder={{t "chat.message_placeholder"}}
       class="sm:w-1/5 md:w-3/5 lg:w-3/4"
       aria-label="{{t "chat.label.input"}}"
+      {{on "paste" this.onPasteInput}}
       data-test-chat-input-message
     />
     {{#if this.hasMessage}}

--- a/app/components/chat/input-message.ts
+++ b/app/components/chat/input-message.ts
@@ -24,7 +24,7 @@ export default class ChatInputMessage extends Component {
 
   async getBase64Data(blob: Blob): Promise<any> {
     return new Promise((resolve, reject) => {
-      var reader = new FileReader();
+      const reader = new FileReader();
       reader.onloadend = () => {
         resolve(reader.result);
       }
@@ -43,7 +43,7 @@ export default class ChatInputMessage extends Component {
 
     for (const file of event.clipboardData.files) {
       if (file.type.startsWith('image/')) {
-        var reader = new FileReader();
+        const reader = new FileReader();
         reader.onload = (onLoadEvent) => {
           if (onLoadEvent.target?.result) {
             this.inputMessage = onLoadEvent.target.result as string;

--- a/app/components/chat/input-message.ts
+++ b/app/components/chat/input-message.ts
@@ -22,6 +22,35 @@ export default class ChatInputMessage extends Component {
     return this.inputMessage.length > 0;
   }
 
+  async getBase64Data(blob: Blob): Promise<any> {
+    return new Promise((resolve, reject) => {
+      var reader = new FileReader();
+      reader.onloadend = () => {
+        resolve(reader.result);
+      }
+      reader.onerror = (err: ProgressEvent) => {
+        reject(err)
+      }
+      reader.readAsDataURL(blob);
+    });
+  }
+
+  @action
+  async onPasteInput() {
+    var items = await navigator.clipboard.read();
+    var imageData = "";
+    for (let item of items) {
+      if (imageData) return;
+      for (let type of item.types) {
+        if (type.startsWith("image/")) {
+          const imageBlob = await item.getType(type);
+          imageData = await this.getBase64Data(imageBlob);
+          this.inputMessage = imageData;
+        }
+      }
+    }
+  }
+
   @action
   sendEmoji(shortcode: string) {
     if (this.inputMessage.length === 0) {

--- a/app/components/chat/input-message.ts
+++ b/app/components/chat/input-message.ts
@@ -36,17 +36,20 @@ export default class ChatInputMessage extends Component {
   }
 
   @action
-  async onPasteInput() {
-    var items = await navigator.clipboard.read();
-    var imageData = "";
-    for (let item of items) {
-      if (imageData) return;
-      for (let type of item.types) {
-        if (type.startsWith("image/")) {
-          const imageBlob = await item.getType(type);
-          imageData = await this.getBase64Data(imageBlob);
-          this.inputMessage = imageData;
+  async onPasteInput(event: ClipboardEvent) {
+    event.preventDefault();
+
+    if (!event.clipboardData) return;
+
+    for (const file of event.clipboardData.files) {
+      if (file.type.startsWith('image/')) {
+        var reader = new FileReader();
+        reader.onload = (onLoadEvent) => {
+          if (onLoadEvent.target?.result) {
+            this.inputMessage = onLoadEvent.target.result as string;
+          }
         }
+        reader.readAsDataURL(file);
       }
     }
   }


### PR DESCRIPTION
ok you can actually copy and paste an image into the chat now. tested in chrome, doesn't work in firefox tho https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read#browser_compatibility 😢
![Screenshot 2023-04-15 051033](https://user-images.githubusercontent.com/2829501/232203269-a728b395-62cc-4a2c-9d2f-56ab02eb3d6c.png)
![Screenshot 2023-04-15 051057](https://user-images.githubusercontent.com/2829501/232203272-9f0166f3-a1e2-4743-b109-ef0d734c00c5.png)
