### PR TITLE
mobile style tweaks

### DIFF
--- a/app/components/add-datafruit.hbs
+++ b/app/components/add-datafruit.hbs
@@ -8,7 +8,7 @@
 
   <await.Fulfilled as |datafruits|>
     {{#if this.showingDatafruits}}
-      <marquee id="add-datafruit-bar">
+      <marquee id="add-datafruit-bar" class="text-sm sm:text-xl">
         [<img style="height: 20px; display: inline;" src="{{this.currentDatafruit.avatarUrlOrDefault}}" alt={{this.currentDatafruit.username}} / >
         <LinkTo @model={{this.currentDatafruit.username}} @route="home.dj">
           {{this.currentDatafruit.username}}
@@ -17,7 +17,7 @@
         <span>
           {{this.currentDatafruit.content}}
         </span>
-        <span class="italic text-sm">
+        <span class="italic text-xs sm:text-sm">
           {{this.currentTimestamp}}
         </span>
       </marquee>

--- a/app/components/datafruits-player.hbs
+++ b/app/components/datafruits-player.hbs
@@ -108,7 +108,7 @@
         {{/if}}
       </span>
     </div>
-    <div class="now-playing flex-grow text-base sm:text-3xl sm:whitespace-nowrap sm:overflow-hidden">
+    <div class="now-playing flex-grow overflow-hidden text-base sm:text-3xl sm:whitespace-nowrap">
       {{#if this.error}}
         <span>
           {{this.error}}

--- a/app/components/datafruits-player.hbs
+++ b/app/components/datafruits-player.hbs
@@ -108,7 +108,7 @@
         {{/if}}
       </span>
     </div>
-    <div class="now-playing flex-grow">
+    <div class="now-playing flex-grow text-base sm:text-3xl sm:whitespace-nowrap sm:overflow-hidden">
       {{#if this.error}}
         <span>
           {{this.error}}
@@ -120,7 +120,7 @@
       {{/if}}
     </div>
     {{#if (and this.playingPodcast this.playing)}}
-      <span class="mx-2">
+      <span class="mx-2 text-base leading-4">
         {{this.formattedPlayTime}}
       </span>
     {{/if}}
@@ -132,7 +132,7 @@
     <div class="seek">
       <div class="seek-bar-wrapper">
         <input
-          class="seek-bar"
+          class="seek-bar m-0 sm:mt-4 sm:mb-4"
           type="range"
           step="any"
           {{on "input" this.seek}}

--- a/app/components/podcast-track.hbs
+++ b/app/components/podcast-track.hbs
@@ -1,8 +1,8 @@
-<div class="podcast py-1 flex space-x-1">
-  <div class="podcast-actions mt-1 text-xl flex space-x-1">
+<div class="sm:py-1 flex space-x-1 text-xs sm:text-xl">
+  <div class="mt-1 flex space-x-1">
     {{#if this.playing}}
       <a
-        class="text-df-green hover:text-df-yellow text-xxl"
+        class="text-df-green hover:text-df-yellow text-xl"
         {{action "pause"}}
         href="#"
       >
@@ -10,7 +10,7 @@
       </a>
     {{else}}
       <a
-        class="text-df-green hover:text-df-yellow text-xxl"
+        class="text-df-green hover:text-df-yellow text-xl"
         {{action "play"}}
         href="#"
       >
@@ -20,7 +20,7 @@
     <a href={{@track.cdnUrl}} download="">
       <FaIcon
         @icon="download"
-        class="fa fa-download text-df-green hover:text-df-yellow text-xxl"
+        class="fa fa-download text-df-green hover:text-df-yellow text-xl"
       />
     </a>
     {{#if @track.youtubeLink}}
@@ -28,7 +28,7 @@
         <FaIcon
           @icon="youtube"
           @prefix="fab"
-          class="text-df-green hover:text-df-yellow text-xxl"
+          class="text-df-green hover:text-df-yellow text-xl"
         />
       </a>
     {{/if}}
@@ -56,13 +56,13 @@
       </button>
     {{/if}}
   {{/if}}
-  <div class="podcast-info mt-1 flex flex-wrap items-center">
+  <div class="mt-1 flex flex-wrap items-center gap-0.5 sm:gap-1.5">
     {{#if @track.scheduledShow}}
       <LinkTo @route="home.show" @model={{@track.scheduledShow}}>
         {{@track.title}}
       </LinkTo>
     {{else}}
-      <span class="text-xl">
+      <span >
         {{@track.title}}
       </span>
     {{/if}}
@@ -75,12 +75,16 @@
             classic:bg-df-pink
             blm:bg-black
             hover:text-white
-            p-1
+            p-0.5
+            p-x-1
+            sm:p-1
+            sm:p-x-2
+            sm:text-base
             uppercase
             border-solid
             border-white
-            border-2
-            p-x-2
+            border
+            sm:border-2
             font-extrabold" >
         {{label.name}}
       </a>

--- a/app/components/podcast-track.hbs
+++ b/app/components/podcast-track.hbs
@@ -1,11 +1,19 @@
-<div class="podcast py-1 flex space-x-1" >
+<div class="podcast py-1 flex space-x-1">
   <div class="podcast-actions mt-1 text-xl flex space-x-1">
     {{#if this.playing}}
-      <a class="text-df-green hover:text-df-yellow text-xxl" {{action "pause"}} href="#">
+      <a
+        class="text-df-green hover:text-df-yellow text-xxl"
+        {{action "pause"}}
+        href="#"
+      >
         {{t "player.pause"}}
       </a>
     {{else}}
-      <a class="text-df-green hover:text-df-yellow text-xxl" {{action "play"}} href="#">
+      <a
+        class="text-df-green hover:text-df-yellow text-xxl"
+        {{action "play"}}
+        href="#"
+      >
         {{t "player.play"}}
       </a>
     {{/if}}
@@ -28,51 +36,54 @@
   {{#if this.session.isAuthenticated}}
     {{#if this.isFavorited}}
       <button
-         class="cool-button favorited"
-         type="button"
-         aria-label="Remove From Favorites"
-         title="Remove From Favorites"
+        class="cool-button favorited"
+        type="button"
+        aria-label="Remove From Favorites"
+        title="Remove From Favorites"
         {{on "click" this.unfavoriteTrack}}
-        >
+      >
         <FaIcon @icon="heart" />
       </button>
     {{else}}
       <button
-         class="cool-button not-favorited"
-         type="button"
-         aria-label="Add To Favorites"
-         title="Add To Favorites"
+        class="cool-button not-favorited"
+        type="button"
+        aria-label="Add To Favorites"
+        title="Add To Favorites"
         {{on "click" this.favoriteTrack}}
-        >
-          <FaIcon @icon="heart" />
+      >
+        <FaIcon @icon="heart" />
       </button>
     {{/if}}
   {{/if}}
   <div class="podcast-info mt-1 flex flex-wrap items-center">
     {{#if @track.scheduledShow}}
-    <LinkTo @route="home.show" @model={{@track.scheduledShow}}>
-      {{@track.title}}
-    </LinkTo>
+      <LinkTo @route="home.show" @model={{@track.scheduledShow}}>
+        {{@track.title}}
+      </LinkTo>
     {{else}}
-    <span class="text-xl">
-      {{@track.title}}
-    </span>
+      <span class="text-xl">
+        {{@track.title}}
+      </span>
     {{/if}}
     {{#each @track.labels as |label|}}
-    <a class="track-label
-                text-df-yellow
-                classic:bg-df-pink
-                blm:bg-black
-                hover:text-white
-                p-1
-                uppercase
-                border-solid
-                border-white
-                border-2
-                p-x-2
-                font-extrabold" {{on "click" (fn this.selectLabel label.name)}} href="#">
-      {{label.name}}
-    </a>
+    <a
+      {{on "click" (fn this.selectLabel label.name)}}
+      href="#" 
+      class="track-label
+            text-df-yellow
+            classic:bg-df-pink
+            blm:bg-black
+            hover:text-white
+            p-1
+            uppercase
+            border-solid
+            border-white
+            border-2
+            p-x-2
+            font-extrabold" >
+        {{label.name}}
+      </a>
     {{/each}}
   </div>
 </div>

--- a/app/components/podcast-track.hbs
+++ b/app/components/podcast-track.hbs
@@ -36,7 +36,7 @@
   {{#if this.session.isAuthenticated}}
     {{#if this.isFavorited}}
       <button
-        class="cool-button favorited"
+        class="cool-button favorited max-h-8"
         type="button"
         aria-label="Remove From Favorites"
         title="Remove From Favorites"
@@ -46,7 +46,7 @@
       </button>
     {{else}}
       <button
-        class="cool-button not-favorited"
+        class="cool-button not-favorited max-h-8"
         type="button"
         aria-label="Add To Favorites"
         title="Add To Favorites"

--- a/app/components/podcast-track.hbs
+++ b/app/components/podcast-track.hbs
@@ -1,5 +1,5 @@
-<div class="py-1 flex flex-wrap space-x-1">
-  <div class="mt-1 text-xl">
+<div class="podcast py-1 flex space-x-1" >
+  <div class="podcast-actions mt-1 text-xl flex space-x-1">
     {{#if this.playing}}
       <a class="text-df-green hover:text-df-yellow text-xxl" {{action "pause"}} href="#">
         {{t "player.pause"}}
@@ -48,36 +48,31 @@
       </button>
     {{/if}}
   {{/if}}
-  {{#if @track.scheduledShow}}
+  <div class="podcast-info mt-1 flex flex-wrap items-center">
+    {{#if @track.scheduledShow}}
     <LinkTo @route="home.show" @model={{@track.scheduledShow}}>
       {{@track.title}}
     </LinkTo>
-  {{else}}
-    <div class="mt-1">
-      <span class="text-xl">
-        {{@track.title}}
-      </span>
-    </div>
-  {{/if}}
-  <div class="flex space-x-2">
+    {{else}}
+    <span class="text-xl">
+      {{@track.title}}
+    </span>
+    {{/if}}
     {{#each @track.labels as |label|}}
-      <a
-        class="track-label
-          text-df-yellow
-          classic:bg-df-pink
-          blm:bg-black
-          hover:text-white
-          p-1
-          uppercase
-          border-solid
-          border-white
-          border-2
-          p-x-2
-          font-extrabold"
-        {{on "click" (fn this.selectLabel label.name)}}
-        href="#">
-        {{label.name}}
-      </a>
+    <a class="track-label
+                text-df-yellow
+                classic:bg-df-pink
+                blm:bg-black
+                hover:text-white
+                p-1
+                uppercase
+                border-solid
+                border-white
+                border-2
+                p-x-2
+                font-extrabold" {{on "click" (fn this.selectLabel label.name)}} href="#">
+      {{label.name}}
+    </a>
     {{/each}}
   </div>
 </div>

--- a/app/components/podcasts.hbs
+++ b/app/components/podcasts.hbs
@@ -19,7 +19,7 @@
           <h1 class="text-center">{{t "podcasts.subscribe_title"}}</h1>
           <div id="podcast-subscribe">
             <div class="md:mx-10 md:my-5 md:py-5">
-              <ul id="subscribe-links" class="pr-2 flex flex-wrap text-xl md:text-m">
+              <ul id="subscribe-links" class="pr-2 flex flex-wrap text-base sm:text-xl">
                 <li>
                   <a href="https://datafruits.streampusher.com/podcasts/datafruits.xml">
                     {{t "podcasts.links.rss"}}

--- a/app/components/sp-nav.hbs
+++ b/app/components/sp-nav.hbs
@@ -1,11 +1,11 @@
 <nav
   id="mobile-navbar"
-  class="pb-3 relative flex justify-between w-full md:hidden items-center mt-3 mr-3 ml-3 "
+  class="relative flex justify-between w-full md:hidden items-center m-0 ml-3 p-0 sm:pb-3 sm:mt-3 sm:mr-3 sm:ml-3 max-h-screen"
   role="navigation">
-  <div class="flex flex-col justify-center">
+  <div class="flex flex-col justify-center h-full">
     <button
       type="button"
-      class="collapsed text-xl"
+      class="collapsed text-xl w-4"
       aria-label={{t "nav_toggle"}}
       {{on "click" @toggleMenu}}>
       <span class="sr-only">
@@ -16,7 +16,7 @@
         aria-hidden="true" />
     </button>
     {{#if @menuOpen}}
-      <ul id="navigation" class="flex flex-wrap">
+      <ul class="flex flex-wrap overflow-y-scroll">
         <li class="py-2 pr-3 text-white text-shadow-light w-full border-dashed border-white border-t-4">
           <span class="" href="#" aria-label={{t "radio.aria"}}>
             {{t "radio.title"}}

--- a/app/components/sp-nav.hbs
+++ b/app/components/sp-nav.hbs
@@ -2,7 +2,7 @@
   id="mobile-navbar"
   class="pb-3 relative flex justify-between w-full md:hidden items-center mt-3 mr-3 ml-3 "
   role="navigation">
-  <div>
+  <div class="flex flex-col justify-center">
     <button
       type="button"
       class="collapsed text-xl"
@@ -16,7 +16,7 @@
         aria-hidden="true" />
     </button>
     {{#if @menuOpen}}
-      <ul class="flex flex-wrap">
+      <ul id="navigation" class="flex flex-wrap">
         <li class="py-2 pr-3 text-white text-shadow-light w-full border-dashed border-white border-t-4">
           <span class="" href="#" aria-label={{t "radio.aria"}}>
             {{t "radio.title"}}
@@ -162,7 +162,7 @@
         </li>
       </ul>
     {{/if}}
-  </div>
+    </div>
   {{#unless @menuOpen}}
 
     <DjDonateModal class="block md ml-5" />

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -825,48 +825,6 @@ body::-webkit-scrollbar-thumb {
   }
 }
 
-.podcast-info {
-  gap:0.25rem;
-}
-
-.podcast {
-  max-width: 100%;
-}
-
-#podcast-search-results {
-
-  @media only screen and (max-width: 600px) {
-
-    .podcast {
-      padding: 1px 0;
-
-      *,
-      .text-xl {
-        font-size: 0.8rem !important;
-      }
-    }
-
-    .podcast-info {
-      margin-top: 0;
-    }
-
-    .track-label {
-      padding: 0 0.175rem;
-      border-width: 1px;
-      // margin:0.1rem;
-    }
-
-    .podcast-actions {
-
-      a,
-      svg {
-        font-size: 1.25rem !important;
-        height: 1.25rem;
-        width: 1.25rem;
-      }
-    }
-  }
-}
 
 @tailwind utilities;
 /* purgecss end ignore */

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -801,6 +801,72 @@ body::-webkit-scrollbar-thumb {
   box-shadow: none;
   @apply border-4 border-dotted border-df-green;
 }
+#mobile-navbar {
+  max-height: 100vh;
+  margin: 0;
+  padding: 12px;
+
+  div:first-child {
+    height: 100%;
+  }
+
+  button {
+    width: 1em;
+  }
+
+  #navigation {
+    max-height: calc(100% - 2em);
+    max-width: 100vw;
+    overflow-y: scroll;
+  }
+
+  @media only screen and (max-width: 600px) {
+    padding: 0 12px;
+  }
+}
+
+.podcast-info {
+  gap:0.25rem;
+}
+
+.podcast {
+  max-width: 100%;
+}
+
+#podcast-search-results {
+
+  @media only screen and (max-width: 600px) {
+
+    .podcast {
+      padding: 1px 0;
+
+      *,
+      .text-xl {
+        font-size: 0.8rem !important;
+      }
+    }
+
+    .podcast-info {
+      margin-top: 0;
+    }
+
+    .track-label {
+      padding: 0 0.175rem;
+      border-width: 1px;
+      // margin:0.1rem;
+    }
+
+    .podcast-actions {
+
+      a,
+      svg {
+        font-size: 1.25rem !important;
+        height: 1.25rem;
+        width: 1.25rem;
+      }
+    }
+  }
+}
 
 @tailwind utilities;
 /* purgecss end ignore */

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -801,30 +801,6 @@ body::-webkit-scrollbar-thumb {
   box-shadow: none;
   @apply border-4 border-dotted border-df-green;
 }
-#mobile-navbar {
-  max-height: 100vh;
-  margin: 0;
-  padding: 12px;
-
-  div:first-child {
-    height: 100%;
-  }
-
-  button {
-    width: 1em;
-  }
-
-  #navigation {
-    max-height: calc(100% - 2em);
-    max-width: 100vw;
-    overflow-y: scroll;
-  }
-
-  @media only screen and (max-width: 600px) {
-    padding: 0 12px;
-  }
-}
-
 
 @tailwind utilities;
 /* purgecss end ignore */

--- a/app/styles/player.scss
+++ b/app/styles/player.scss
@@ -265,16 +265,21 @@ audio {
   display: none;
 }
 
-div.radio-bar {
-  line-height: 1;
-  width:100%;
-  color:white;
-  text-decoration:none;
-  font-size: 25px;
-  text-shadow: #333 1px 1px 1px;
-  padding: 5px 0;
-  @media only screen and (max-device-width: 480px) {
-    font-size:1.5rem;
+div.radio-container {
+
+  @media only screen and (max-width: 600px) {
+
+    .now-playing,
+    marquee {
+      font-size: 1rem;
+      line-height: 18px;
+    }
+
+    .now-playing {
+      white-space: initial;
+      //      text-wrap: normal;
+    }
+
     #next-show {
       display: none;
     }

--- a/app/styles/player.scss
+++ b/app/styles/player.scss
@@ -18,8 +18,6 @@
     min-width: 65px;
   }
   .now-playing {
-    white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
     display: inline-block;
     &:not(:hover) {
@@ -73,7 +71,6 @@ div.radio-bar a:hover {
   justify-content: center;
   input[type=range] {
     -webkit-appearance: none;
-    margin: 18px 0;
     width: 100%;
   }
   input[type=range]:focus {
@@ -266,24 +263,6 @@ audio {
 }
 
 div.radio-container {
-
-  @media only screen and (max-width: 600px) {
-
-    .now-playing,
-    marquee {
-      font-size: 1rem;
-      line-height: 18px;
-    }
-
-    .now-playing {
-      white-space: initial;
-      //      text-wrap: normal;
-    }
-
-    #next-show {
-      display: none;
-    }
-  }
   label {
     font-family: cursive;
   }


### PR DESCRIPTION
Wanted to use the site a little easier with my tiny iPhone 5 so I adjusted the style a bit behind media queries

The navigation menu can scroll up an down if the screen is shorter than contents.

I also added a media query to reduce the font size for the now playing text, the podcast archive page, and I added indentation for a cleaner layout in the list of podcasts. No more horizontal scrolling.

thanks for checking out this pull request

Brad