### PR TITLE
Experimental grid-based Archive/Podcasts view

### DIFF
--- a/app/components/podcast-track.hbs
+++ b/app/components/podcast-track.hbs
@@ -1,63 +1,15 @@
-<div class="bg-df-pink text-2xl rounded-lg sm:py-1 flex justify-between space-x-1 text-xs sm:text-xl mb-2 p-2">
-  <div class="flex flex-wrap items-center gap-0.5 sm:gap-1.5">
-    <div class="mt-1 flex space-x-1">
-      {{#if this.playing}}
-        <a
-          class="text-df-green hover:text-df-yellow text-xl"
-          {{action "pause"}}
-          href="#"
-        >
-          {{t "player.pause"}}
-        </a>
-      {{else}}
-        <a
-          class="text-df-green hover:text-df-yellow text-xl"
-          {{action "play"}}
-          href="#"
-        >
-          {{t "player.play"}}
-        </a>
-      {{/if}}
-      <a href={{@track.cdnUrl}} download="">
-        <FaIcon
-          @icon="download"
-          class="fa fa-download text-df-green hover:text-df-yellow text-xl"
-        />
-      </a>
-      {{#if @show.youtubeLink}}
-        <a href={{@show.youtubeLink}} target="_blank" rel="noreferrer noopener">
-          <FaIcon
-            @icon="youtube"
-            @prefix="fab"
-            class="text-df-green hover:text-df-yellow text-xl"
-          />
-        </a>
-      {{/if}}
-      {{#if this.session.isAuthenticated}}
-        {{#if this.isFavorited}}
-          <button
-            class="cool-button favorited max-h-8"
-            type="button"
-            aria-label="Remove From Favorites"
-            title="Remove From Favorites"
-            {{on "click" this.unfavoriteTrack}}
-          >
-            <FaIcon @icon="heart" />
-          </button>
-        {{else}}
-          <button
-            class="cool-button not-favorited max-h-8"
-            type="button"
-            aria-label="Add To Favorites"
-            title="Add To Favorites"
-            {{on "click" this.favoriteTrack}}
-          >
-            <FaIcon @icon="heart" />
-          </button>
-        {{/if}}
-      {{/if}}
-    </div>
-    <div class="mt-1 flex flex-wrap items-center gap-0.5 sm:gap-1.5">
+<div class="flex flex-col gap-2 p-2 bg-df-pink text-2xl rounded-lg text-xs sm:text-xl">
+
+  {{! show pic }}
+  <div
+    class="w-full h-32 bg-center bg-cover overflow-hidden rounded-md"
+    style="{{this.backgroundStyle}}"
+  >
+  </div>
+  
+  {{! show name }}
+  <div class="flex flex-col gap-0.5 sm:gap-1.5">
+    <div class="flex flex-wrap gap-0.5 sm:gap-1.5">
       <div>
         <LinkTo
           @route="home.shows.episode"
@@ -73,23 +25,93 @@
       {{/each}}
     </div>
   </div>
-  <div
-    class="w-1/2 bg-center bg-cover block overflow-hidden rounded-xl"
-    style="{{this.backgroundStyle}}"
-  >
-  </div>
-  <div>
-    <span class="text-sm mr-2 font-cursive">
-      <LinkTo @route="home.dj" @model={{@show.hostedBy}}>
-        {{@show.hostedBy}}
-      </LinkTo>
-    </span>
-    <span>
-      <img
-        style="height: 3rem;"
-        class="inline rounded-lg"
-        src="{{@show.hostAvatarUrl}}"
-        />
-    </span>
-  </div>
+
+
+  {{! spacer to make the layout flow nice}}
+  <div class="flex-1"></div>
+
+  {{! DJ + buttons }}
+  <div class="flex flex-cols sm:flex-rows justify-between items-center  gap-2">
+  
+    {{! DJ avatar + name }}
+    <div class="flex-auto flex flex-cols items-center gap-2">
+
+      {{! avatar }}
+      <span class="flex-none">
+        <img
+          style="height: 2rem;"
+          class="inline rounded-lg"
+          src="{{@show.hostAvatarUrl}}"
+          />
+      </span>
+
+      {{! name }}
+      <span class="flex-auto text-sm font-cursive leading-tight">
+        <LinkTo @route="home.dj" @model={{@show.hostedBy}}>
+          {{@show.hostedBy}}
+        </LinkTo>
+      </span>
+    </div>
+
+    {{! buttons }}
+    <div class="flex-none flex flex-cols gap-2 space-x-1">
+        {{#if this.playing}}
+          <a
+            class="text-df-green hover:text-df-yellow text-xl"
+            {{action "pause"}}
+            href="#"
+          >
+            {{t "player.pause"}}
+          </a>
+        {{else}}
+          <a
+            class="text-df-green hover:text-df-yellow text-xl"
+            {{action "play"}}
+            href="#"
+          >
+            {{t "player.play"}}
+          </a>
+        {{/if}}
+        <a href={{@track.cdnUrl}} download="">
+          <FaIcon
+            @icon="download"
+            class="fa fa-download text-df-green hover:text-df-yellow text-xl"
+          />
+        </a>
+        {{#if @show.youtubeLink}}
+          <a href={{@show.youtubeLink}} target="_blank" rel="noreferrer noopener">
+            <FaIcon
+              @icon="youtube"
+              @prefix="fab"
+              class="text-df-green hover:text-df-yellow text-xl"
+            />
+          </a>
+        {{/if}}
+        {{#if this.session.isAuthenticated}}
+          {{#if this.isFavorited}}
+            <button
+              class="cool-button favorited max-h-8"
+              type="button"
+              aria-label="Remove From Favorites"
+              title="Remove From Favorites"
+              {{on "click" this.unfavoriteTrack}}
+            >
+              <FaIcon @icon="heart" />
+            </button>
+          {{else}}
+            <button
+              class="cool-button not-favorited max-h-8"
+              type="button"
+              aria-label="Add To Favorites"
+              title="Add To Favorites"
+              {{on "click" this.favoriteTrack}}
+            >
+              <FaIcon @icon="heart" />
+            </button>
+          {{/if}}
+        {{/if}}
+      </div>
+
+
+    </div>
 </div>

--- a/app/components/podcasts.hbs
+++ b/app/components/podcasts.hbs
@@ -6,6 +6,8 @@
       id="podcast-search-controls"
       {{did-update await.reload @page}}
       >
+
+      {{! search and subscribe }}
       <div class="flex flex-wrap justify-around">
         <div id="search-controls">
           <h2 class="text-center">{{t "podcasts.search_title"}}</h2>
@@ -46,7 +48,11 @@
           </div>
         </div>
       </div>
+
+
       <br>
+
+      {{! podcast results }}
       <div id="podcast-search-results">
         <await.Pending>
           <p id="podcast-search-loading" class="">
@@ -62,7 +68,8 @@
             @page={{@page}}
             @route="home.podcasts" />
           </span>
-          <div class="p-2">
+
+          <div class="grid grid-cols-episodes gap-4 p-4">
             {{#each result as |show|}}
               {{#if show.tracks.firstObject}}
                 <PodcastTrack
@@ -75,6 +82,7 @@
               {{t "podcasts.no_result"}}
             {{/each}}
           </div>
+          
           <FruitsUi::Pagination
             @totalPages={{result.meta.total_pages}}
             @page={{@page}}

--- a/app/tailwind/config.js
+++ b/app/tailwind/config.js
@@ -28,6 +28,9 @@ module.exports = {
         'df-green': '#41d069',
         'df-green-dark': '#289244',
       },
+      gridTemplateColumns: {
+        episodes: 'repeat(auto-fit,minmax(240px,1fr))'
+      }
     },
     themeVariants: ['classic', 'blm', 'trans'],
   },


### PR DESCRIPTION
As asked for in the Discord, here's an experimental responsive grid-based view for Archive ^^.

Changes:
- Changed the archive results to a responsive grid-based layout instead of rows.
- Added a new custom class to Tailwind to create this grid layout.
- Added comments to the hbs files I edited to make this change. I hope that wasn't an overreach. ^^'