### PR TITLE
change chat text color

### DIFF
--- a/app/components/chat-settings.hbs
+++ b/app/components/chat-settings.hbs
@@ -19,6 +19,7 @@
           @enabled={{this.videoStream.displaying}}
         />
       {{/if}}
+      <Chat::ColorPicker />
     </div>
   </Ui::Modal>
 {{/if}}

--- a/app/components/chat/color-picker.hbs
+++ b/app/components/chat/color-picker.hbs
@@ -2,12 +2,12 @@
   id="chat-text-color-picker-label"
   for="chat-text-color-picker"
 >
-  Chat Color
+  {{t "chat.settings.chat_color"}}
 </label>
 <input 
   id="chat-text-color-picker"
   name="chat-text-color-picker"
   type="color"
-  value={{this.chatText.color}}
+  value={{this.hexValue}}
   {{on "input" this.selectedColor}}
 >

--- a/app/components/chat/color-picker.hbs
+++ b/app/components/chat/color-picker.hbs
@@ -8,6 +8,6 @@
   id="chat-text-color-picker"
   name="chat-text-color-picker"
   type="color"
-  value="#fff940"
+  value={{this.chatText.color}}
   {{on "input" this.selectedColor}}
 >

--- a/app/components/chat/color-picker.hbs
+++ b/app/components/chat/color-picker.hbs
@@ -1,0 +1,13 @@
+<label
+  id="chat-text-color-picker-label"
+  for="chat-text-color-picker"
+>
+  Chat Color
+</label>
+<input 
+  id="chat-text-color-picker"
+  name="chat-text-color-picker"
+  type="color"
+  value="#fff940"
+  {{on "input" this.selectedColor}}
+>

--- a/app/components/chat/color-picker.js
+++ b/app/components/chat/color-picker.js
@@ -6,11 +6,13 @@ import { inject as service } from "@ember/service";
 export default class ColorPicker extends Component {
   @oneWay("chatText.color") style;
 
-  @service
-  chatText;
+  @service chatText;
 
   @action
   selectedColor(event) {
-    this.chatText.setColor(event.target.value);
+    if (event.target.value) {
+      this.chatText.setColor(event.target.value);
+      localStorage.setItem("datafruits-chat-color", event.target.value);
+    }
   }
 }

--- a/app/components/chat/color-picker.js
+++ b/app/components/chat/color-picker.js
@@ -1,6 +1,5 @@
 import Component from "@glimmer/component";
 import { action } from "@ember/object";
-import { oneWay } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 
 export default class ColorPicker extends Component {

--- a/app/components/chat/color-picker.js
+++ b/app/components/chat/color-picker.js
@@ -8,6 +8,10 @@ export default class ColorPicker extends Component {
     return this.chatText.color;
   }
 
+  get hexValue() {
+    return `#${this.style.split("#")[1]}`;
+  }
+
   @service chatText;
 
   @action

--- a/app/components/chat/color-picker.js
+++ b/app/components/chat/color-picker.js
@@ -4,7 +4,9 @@ import { oneWay } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 
 export default class ColorPicker extends Component {
-  @oneWay("chatText.color") style;
+  get style() {
+    return this.chatText.color;
+  }
 
   @service chatText;
 

--- a/app/components/chat/color-picker.js
+++ b/app/components/chat/color-picker.js
@@ -1,0 +1,16 @@
+import Component from "@glimmer/component";
+import { action } from "@ember/object";
+import { oneWay } from "@ember/object/computed";
+import { inject as service } from "@ember/service";
+
+export default class ColorPicker extends Component {
+  @oneWay("chatText.color") style;
+
+  @service
+  chatText;
+
+  @action
+  selectedColor(event) {
+    this.chatText.setColor(event.target.value);
+  }
+}

--- a/app/components/datafruits-chat.hbs
+++ b/app/components/datafruits-chat.hbs
@@ -7,9 +7,10 @@
     <h1>{{t "chat.loading"}}</h1>
   {{else}}
     <div id="chat-area"
-      class="text-df-yellow font-bold flex flex-row flex-grow min-h-0 relative text-shadow mb-5 flex-basis-0"
+      class="font-bold flex flex-row flex-grow min-h-0 relative text-shadow mb-5 flex-basis-0"
+      style={{this.color}}
       {{did-insert this.didInsert}}
-      >
+    >
       <ChatMessages
         @messages={{this.chat.messages}}
         @gifsEnabled={{this.chat.gifsEnabled}}

--- a/app/components/datafruits-chat.js
+++ b/app/components/datafruits-chat.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { formatEmojiHtml } from 'datafruits13/helpers/format-emoji-html';
-import { oneWay } from '@ember/object/computed';
 
 export default class DatafruitsChat extends Component {
   @service chat;

--- a/app/components/datafruits-chat.js
+++ b/app/components/datafruits-chat.js
@@ -3,10 +3,14 @@ import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import Component from '@glimmer/component';
 import { formatEmojiHtml } from 'datafruits13/helpers/format-emoji-html';
+import { oneWay } from '@ember/object/computed';
 
 export default class DatafruitsChat extends Component {
-  @service
-  chat;
+  @service chat;
+
+  @oneWay('chatText.color') color;
+
+  @service chatText;
 
   @tracked nick = '';
   @tracked newMessagesBelow = false; // TODO move this to chat service

--- a/app/components/datafruits-chat.js
+++ b/app/components/datafruits-chat.js
@@ -8,9 +8,9 @@ import { oneWay } from '@ember/object/computed';
 export default class DatafruitsChat extends Component {
   @service chat;
 
-get color() {
-  return this.chatText.color;
-}
+  get color() {
+    return this.chatText.color;
+  }
 
   @service chatText;
 

--- a/app/components/datafruits-chat.js
+++ b/app/components/datafruits-chat.js
@@ -8,7 +8,9 @@ import { oneWay } from '@ember/object/computed';
 export default class DatafruitsChat extends Component {
   @service chat;
 
-  @oneWay('chatText.color') color;
+get color() {
+  return this.chatText.color;
+}
 
   @service chatText;
 

--- a/app/services/chat-text.js
+++ b/app/services/chat-text.js
@@ -5,7 +5,7 @@ export default class ChatTextService extends Service {
   @tracked color = "color: #fff940";
 
   setColor(hexCode) {
-    this.set("color", "color: " + hexCode);
+    this.color = "color: " + hexCode;
   }
 
   constructor() {

--- a/app/services/chat-text.js
+++ b/app/services/chat-text.js
@@ -7,4 +7,14 @@ export default class ChatTextService extends Service {
   setColor(hexCode) {
     this.set("color", "color: " + hexCode);
   }
+
+  constructor() {
+    super(...arguments);
+
+    const storedColor = localStorage.getItem("datafruits-chat-color");
+
+    if (storedColor) {
+      this.color = `color: ${storedColor}`;
+    }
+  }
 }

--- a/app/services/chat-text.js
+++ b/app/services/chat-text.js
@@ -1,0 +1,10 @@
+import Service from "@ember/service";
+import { tracked } from "@glimmer/tracking";
+
+export default class ChatTextService extends Service {
+  @tracked color = "color: #fff940";
+
+  setColor(hexCode) {
+    this.set("color", "color: " + hexCode);
+  }
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -317,6 +317,11 @@ pre {
   }
 }
 
+// make links in chat change the same color if it's changed
+#chat-area a {
+  color: inherit;
+}
+
 .modal-body form div {
   padding-top: 0.2rem;
   padding-bottom: 0.2rem;

--- a/translations/en.json
+++ b/translations/en.json
@@ -54,7 +54,8 @@
     "search": "\"dancing\", \"music\", ...",
     "settings": {
       "show_images": "Show Images",
-      "show_video": "Show Video"
+      "show_video": "Show Video",
+      "chat_color": "Chat Color"
     },
     "label": {
       "nick": "nickname",


### PR DESCRIPTION
carrying on the work from an old branch #412  that adds a color picker that changes the color of the text in the chat room
![demonstrating that all of the chat messages, usernames, and timestamps are changing colors when selected by the color picker utility](https://github.com/datafruits/datafruits/assets/2829501/793f37ea-65d5-4da4-9fc3-52d676e65500)

few things to address:
 - [x] changes are not saved; this should be like the volume control
 - [ ] buddy list will show yellow links on mobile because they aren't in `#chat-area`
