### PR TITLE
Get djs by default

### DIFF
--- a/app/components/djs/list.hbs
+++ b/app/components/djs/list.hbs
@@ -42,13 +42,11 @@
           </div>
         {{/each}}
       </div>
-      <!--
       <FruitsUi::Pagination
         @totalPages={{result.meta.total_pages}}
         @page={{@searchParams.page}}
         @route={{this.router.currentRouteName}}
       />
-      -->
     </await.Fulfilled>
     <await.Rejected>
       error ... :(

--- a/app/components/pc-nav.hbs
+++ b/app/components/pc-nav.hbs
@@ -107,6 +107,7 @@
           class="its-just-a-website-sub-menu-item"
           aria-label={{t "djs.aria"}}
           @route="home.djs"
+          @query={{hash tags="dj"}}
         >
           {{t "djs.title"}}
         </LinkTo>

--- a/app/components/sp-nav.hbs
+++ b/app/components/sp-nav.hbs
@@ -41,6 +41,7 @@
                   class="text-white text-shadow-light"
                   aria-label={{t "djs.aria"}}
                   @route="home.djs"
+                  @query={{hash tags="dj"}}
                 >
                   {{t "djs.title"}}
                 </LinkTo>

--- a/app/router.js
+++ b/app/router.js
@@ -19,7 +19,7 @@ Router.map(function () {
     this.route('shows.episode', { path: '/shows/:showSeriesSlug/episodes/:slug' });
     this.route('dj-inquiry');
     this.route('coc');
-    this.route('djs', { path: '/djs?tags=dj'});
+    this.route('djs', { path: '/djs'});
     this.route('dj', { path: '/djs/:name' });
     this.route('chat');
     this.route('cat');

--- a/app/router.js
+++ b/app/router.js
@@ -19,7 +19,7 @@ Router.map(function () {
     this.route('shows.episode', { path: '/shows/:showSeriesSlug/episodes/:slug' });
     this.route('dj-inquiry');
     this.route('coc');
-    this.route('djs');
+    this.route('djs', { path: '/djs?tags=dj'});
     this.route('dj', { path: '/djs/:name' });
     this.route('chat');
     this.route('cat');

--- a/app/router.js
+++ b/app/router.js
@@ -19,7 +19,7 @@ Router.map(function () {
     this.route('shows.episode', { path: '/shows/:showSeriesSlug/episodes/:slug' });
     this.route('dj-inquiry');
     this.route('coc');
-    this.route('djs', { path: '/djs'});
+    this.route('djs');
     this.route('dj', { path: '/djs/:name' });
     this.route('chat');
     this.route('cat');


### PR DESCRIPTION
when navigating to the fruits page (aka 'djs'), it takes a long time for all possible users to return. Since the route is called 'djs', maybe it should default to users with the DJ role?

Also, there should be pagination because even filtering by DJs takes a long time for the backend to process.