### PR TITLE
cleanup episode form

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,6 +6,7 @@ module.exports = {
       files: '*.{js,ts}',
       options: {
         singleQuote: true,
+        printWidth: 120,
       },
     },
   ],

--- a/app/components/labels-select.hbs
+++ b/app/components/labels-select.hbs
@@ -1,10 +1,8 @@
-<section
-  ...attributes
-  >
-  <h4 class="block text-sm font-bold mb-2">Tags</h4>
+<section ...attributes>
+  <label class="block text-sm font-bold mb-2 text-df-yellow">Tags</label>
   {{#if this.error}}
     <div class="error">
-        {{this.error}}
+      {{this.error}}
     </div>
   {{/if}}
   <PowerSelectMultipleWithCreate
@@ -15,7 +13,9 @@
     @renderInPlace={{true}}
     @onChange={{this.setSelectedLabels}}
     @onCreate={{this.createTag}}
-    @showCreateWhen={{this.hideCreateOptionOnSameName}} as |label|>
+    @showCreateWhen={{this.hideCreateOptionOnSameName}}
+    as |label|
+  >
     {{label.name}}
   </PowerSelectMultipleWithCreate>
 </section>

--- a/app/components/my-shows/episode-form.hbs
+++ b/app/components/my-shows/episode-form.hbs
@@ -1,156 +1,174 @@
 {{#let (changeset @episode this.EpisodeValidations) as |changeset|}}
   <Ui::ChangesetForm
+    @containerClass="page-spacing"
+    @changeset={{changeset}}
+    @onError={{this.onError}}
+    @onSubmit={{this.onSubmit}}
+    as |Form|
+  >
+    <h5 class="italic text-xs">(episode update form)</h5>
+    <section class="my-2">
+      <div class="flex justify-start italic text-sm my-1">
+        <span>
+          {{t "profile.my-shows.form.air-date"}}
+        </span>
+        <span>
+          {{format-day @episode.start}}
+          -
+          {{format-time @episode.start}}
+        </span>
+      </div>
+      <Form.Input
+        @label={{t "profile.my-shows.form.title"}}
+        @fieldName="title"
+        @containerClass="mb-2 flex justify-between"
+      />
+      <Form.Textarea
+        @label={{t "profile.my-shows.form.description"}}
+        @fieldName="description"
+        @containerClass="mb-2 flex justify-between"
+        @size="lg"
+        @value={{changeset.description}}
+        rows="5"
+        cols="35"
+      />
+      <LabelsSelect
+        class="my-2 flex justify-between"
         @changeset={{changeset}}
-        @onError={{this.onError}}
-        @onSubmit={{this.onSubmit}} as |Form|>
-      <section class="flex">
-        <div>
-          <Form.Input
-            @label={{t "profile.my-shows.form.title"}}
-            @fieldName="title"
-            @containerClass='mb-2'
+      />
+      {{! episode artwork uploader }}
+      <div class="flex justify-start mb-4">
+
+        <label class="align-top" for="show-artwork">
+          {{t "profile.my-shows.form.artwork"}}
+        </label>
+        <input
+          class="text-df-yellow semibold border-dashed"
+          id="showArtwork"
+          name="showArtwork"
+          type="file"
+          accept="image/*"
+          {{on "change" this.updateFile}}
+        />
+        {{#if @episode.isNew}}
+          {{#if changeset.image}}
+            <img
+              alt="artwork"
+              width="300"
+              height="300"
+              src="{{changeset.image}}"
             />
-          <div>
-            <div>
-              <span>{{t "profile.my-shows.form.air-date"}}</span> {{format-day @episode.start}} - {{format-time @episode.start}}
-            </div>
-            <label class="align-top" for="show-artwork"> {{t "profile.my-shows.form.artwork"}}</label>
-            <br/>
-            {{#if @episode.isNew}}
-              {{#if changeset.image}}
-                <img alt="artwork" width="300" height="300"
-                  src="{{changeset.image}}">
-              {{/if}}
-            {{else}}
-              {{#if changeset.thumbImageUrl}}
-                <img alt="artwork" width="300" height="300"
-                  src="{{changeset.thumbImageUrl}}">
-              {{/if}}
-            {{/if}}
-            <input
-              class="py-4 px-4 my-2 text-df-yellow w-full semibold border-dashed"
-              id="showArtwork"
-              name="showArtwork"
-              type="file"
-              accept="image/*"
-              {{on "change" this.updateFile}}
+          {{/if}}
+        {{else}}
+          {{#if changeset.thumbImageUrl}}
+            <img
+              alt="artwork"
+              width="300"
+              height="300"
+              src="{{changeset.thumbImageUrl}}"
             />
-          </div>
-          <Form.Textarea
-            @label={{t "profile.my-shows.form.description"}}
-            @fieldName="description"
-            @containerClass='mb-2'
-            @size='lg'
-            @value={{changeset.description}}
-            rows='20'
-            cols='50'
-            />
-          <TimePicker
-            @property="start"
-            @changeset={{changeset}}
-            @onChange={{this.setEndAfterStart}}
-            />
-          <TimePicker
-            @property="end"
-            @changeset={{changeset}}
-            @startTime={{changeset.start}}
-            />
-          {{#if @episode.airDatePassed}}
-            <h2
-              class="text-x">
-              {{t "profile.my-shows.form.archive"}}
-            </h2>
-            <Form.Checkbox
-              @type="checkbox"
-              @label={{t "profile.my-shows.form.prerecorded-archive"}}
-              id="use-prerecord"
-              @fieldName="usePrerecordedFileForArchive"
-              />
-            <TrackUploader @changeset={{changeset}} />
-            {{#if @episode.prerecordTrackFilename}}
-              <span>{{@episode.prerecordTrackFilename}}</span>
-            {{/if}}
-            <div class="mb-2">
-              <h3
-                class="text-l">
-                {{t "profile.my-shows.form.select-recording"}}
-              </h3>
-              <MyShows::RecordingsSearch
-                @changeset={{changeset}}
-                />
-            </div>
-            <Form.Input
-              @label={{t "profile.my-shows.form.youtube-link"}}
-              @fieldName="youtubeLink"
-              @containerClass='mb-2'
-            />
-            <Form.Input
-              @label={{t "profile.my-shows.form.mixcloud-link"}}
-              @fieldName="mixcloudLink"
-              @containerClass='mb-2'
-            />
-            <Form.Input
-              @label={{t "profile.my-shows.form.soundcloud-link"}}
-              @fieldName="soundcloudLink"
-              @containerClass='mb-2'
-            />
-            <label for="archive-status">{{t "profile.my-shows.form.archive-status"}}</label>
+          {{/if}}
+        {{/if}}
+
+      </div>
+      {{#if @episode.airDatePassed}}
+        <div class="">
+
+          <MyShows::RecordingSelector @changeset={{changeset}} />
+          <div class="my-2 flex justify-between">
+
+            <label for="archive-status">
+              {{t "profile.my-shows.form.archive-status"}}
+            </label>
             <select
               id="archive-status"
+              name="archive-status"
               {{on "change" (pick "target.value" (set changeset "status"))}}
             >
               {{#each-in this.statusOptions as |key val|}}
-                <option
-                  value="{{val}}"
-                  selected={{eq changeset.status val}}
-                  >
+                <option value="{{val}}" selected={{eq changeset.status val}}>
                   {{key}}
                 </option>
               {{/each-in}}
             </select>
-          {{else}}
-            <h2
-              class="text-x">
-              {{t "profile.my-shows.form.prerecorded-set"}}
-            </h2>
-            <TrackUploader
-              @changeset={{changeset}}
-              @onStartUpload={{this.onStartUpload}}
-              @onFinishUpload={{this.onFinishUpload}}
+          </div>
+          <div class="my-2 py-2 border-2 border-red-400 border-dashed">
+            <Form.Input
+              @label={{t "profile.my-shows.form.youtube-link"}}
+              @fieldName="youtubeLink"
+              @containerClass="mb-2 flex justify-between"
             />
-            {{#if changeset.prerecordTrackId}}
-              {{changeset.prerecordTrackFilename}}
-            {{/if}}
-          {{/if}}
+            <Form.Input
+              @label={{t "profile.my-shows.form.mixcloud-link"}}
+              @fieldName="mixcloudLink"
+              @containerClass="mb-2 flex justify-between"
+            />
+            <Form.Input
+              @label={{t "profile.my-shows.form.soundcloud-link"}}
+              @fieldName="soundcloudLink"
+              @containerClass="mb-2 flex justify-between"
+            />
+          </div>
         </div>
-      </section>
-      <LabelsSelect
-        class="mb-2"
-        @changeset={{changeset}}
+      {{else}}
+        {{! airdate has *not* passed; its an upcoming show }}
+        <div>
+          <TimePicker
+            @label="Start time"
+            @property="start"
+            @changeset={{changeset}}
+            @onChange={{this.setEndAfterStart}}
+          />
+          <TimePicker
+            @label="Duration"
+            @property="end"
+            @changeset={{changeset}}
+            @startTime={{changeset.start}}
+          />
+        </div>
+        <h4>
+          {{t "profile.my-shows.form.prerecorded-set"}}
+        </h4>
+        <TrackUploader
+          @changeset={{changeset}}
+          @onStartUpload={{this.onStartUpload}}
+          @onFinishUpload={{this.onFinishUpload}}
         />
-      <div class="mb-4">
+        {{#if changeset.prerecordTrackId}}
+          {{changeset.prerecordTrackFilename}}
+        {{/if}}
+      {{/if}}
+    </section>
+
+    <div class="mb-4">
+      <Button
+        @type="submit"
+        @intent="primary"
+        disabled={{(or
+          (eq this.isUploading true)
+          (or Form.state.hasSubmitted changeset.isInvalid)
+        )}}
+        class="cool-button mb-2"
+      >
+        {{t "profile.my-shows.form.update"}}
+      </Button>
+    </div>
+    {{#if
+      (or
+        (eq this.currentUser.user.username @episode.hostedBy)
+        (includes "admin" this.currentUser.user.roles)
+      )
+    }}
+      <div>
         <Button
-          @type='submit'
-          @intent='primary'
-          disabled={{
-            (or (eq this.isUploading true) (or Form.state.hasSubmitted changeset.isInvalid))
-          }}
-          class='cool-button mb-2'
-          >
-          {{t "profile.my-shows.form.update"}}
+          @type="submit"
+          @intent="danger"
+          class="cool-button mb-2 danger"
+          {{on "click" this.deleteEpisode}}
+        >
+          {{t "profile.my-shows.form.delete"}}
         </Button>
       </div>
-      {{#if (or (eq this.currentUser.user.username @episode.hostedBy) (includes 'admin' this.currentUser.user.roles))}}
-        <div>
-          <Button
-            @type='submit'
-            @intent='danger'
-            class='cool-button mb-2 danger'
-            {{on "click" this.deleteEpisode}}
-            >
-            {{t "profile.my-shows.form.delete"}}
-          </Button>
-        </div>
-      {{/if}}
+    {{/if}}
   </Ui::ChangesetForm>
 {{/let}}

--- a/app/components/my-shows/episode-form.hbs
+++ b/app/components/my-shows/episode-form.hbs
@@ -113,21 +113,21 @@
             </select>
           </div>
           <MyShows::RecordingSelector @changeset={{changeset}} />
-          <div class="my-2 py-2 border-2 border-red-400 border-dashed">
+          <div class="my-2 py-2">
             <Form.Input
               @label={{t "profile.my-shows.form.youtube-link"}}
               @fieldName="youtubeLink"
-              @containerClass="mb-2 flex justify-between"
+              @containerClass="mb-2"
             />
             <Form.Input
               @label={{t "profile.my-shows.form.mixcloud-link"}}
               @fieldName="mixcloudLink"
-              @containerClass="mb-2 flex justify-between"
+              @containerClass="mb-2"
             />
             <Form.Input
               @label={{t "profile.my-shows.form.soundcloud-link"}}
               @fieldName="soundcloudLink"
-              @containerClass="mb-2 flex justify-between"
+              @containerClass="mb-2"
             />
           </div>
         </div>

--- a/app/components/my-shows/episode-form.hbs
+++ b/app/components/my-shows/episode-form.hbs
@@ -6,77 +6,97 @@
     @onSubmit={{this.onSubmit}}
     as |Form|
   >
-    <h5 class="italic text-xs">(episode update form)</h5>
     <section class="my-2">
+
+      {{! header and time stamp}}
       <div class="flex justify-start italic text-sm my-1">
-        <span>
-          {{t "profile.my-shows.form.air-date"}}
-        </span>
+        <span>{{t "profile.my-shows.form.air-date"}}</span>
         <span>
           {{format-day @episode.start}}
           -
           {{format-time @episode.start}}
         </span>
       </div>
-      <Form.Input
-        @label={{t "profile.my-shows.form.title"}}
-        @fieldName="title"
-        @containerClass="mb-2 flex justify-between"
-      />
-      <Form.Textarea
-        @label={{t "profile.my-shows.form.description"}}
-        @fieldName="description"
-        @containerClass="mb-2 flex justify-between"
-        @size="lg"
-        @value={{changeset.description}}
-        rows="5"
-        cols="35"
-      />
-      <LabelsSelect
-        class="my-2 flex justify-between"
-        @changeset={{changeset}}
-      />
-      {{! episode artwork uploader }}
-      <div class="flex justify-start mb-4">
 
+      {{! title, description, and tag input }}
+      <div>
+        <Form.Input
+          @label={{t "profile.my-shows.form.title"}}
+          @fieldName="title"
+          @containerClass="mb-2 flex justify-start gap-4"
+        />
+        <Form.Textarea
+          @label={{t "profile.my-shows.form.description"}}
+          @fieldName="description"
+          @containerClass="mb-2 flex justify-start gap-4"
+          @size="lg"
+          @value={{changeset.description}}
+          rows="5"
+          cols="35"
+        />
+        <LabelsSelect
+          class="my-2 flex justify-start gap-4"
+          @changeset={{changeset}}
+        />
+      </div>
+
+      {{! episode artwork uploader }}
+      <div class="flex justify-start gap-10 mb-4 relative">
         <label class="align-top" for="show-artwork">
           {{t "profile.my-shows.form.artwork"}}
         </label>
-        <input
-          class="text-df-yellow semibold border-dashed"
-          id="showArtwork"
-          name="showArtwork"
-          type="file"
-          accept="image/*"
-          {{on "change" this.updateFile}}
-        />
-        {{#if @episode.isNew}}
-          {{#if changeset.image}}
-            <img
-              alt="artwork"
-              width="300"
-              height="300"
-              src="{{changeset.image}}"
-            />
-          {{/if}}
-        {{else}}
-          {{#if changeset.thumbImageUrl}}
-            <img
-              alt="artwork"
-              width="300"
-              height="300"
-              src="{{changeset.thumbImageUrl}}"
-            />
-          {{/if}}
-        {{/if}}
 
+        {{#let (episode-image-url changeset) as |imageUrl|}}
+          {{#if imageUrl}}
+            <div class="relative">
+              <img
+                alt="your show's artwork for this episode"
+                width="300"
+                height="300"
+                src={{imageUrl}}
+              />
+              <div
+                class="absolute size-24 bottom-0 left-0 flex items-center gap-2"
+              >
+                <label for="showArtwork">
+                  <input
+                    class="text-df-yellow semibold border-dashed"
+                    id="showArtwork"
+                    name="showArtwork"
+                    type="file"
+                    accept="image/*"
+                    {{on "change" this.updateFile}}
+                  />
+                </label>
+                <button
+                  type="button"
+                  class="cool-button"
+                  name="change"
+                  title="Remove artwork"
+                  {{on "click" (fn this.deleteFile changeset)}}
+                >
+                  X
+                </button>
+              </div>
+            </div>
+          {{else}}
+            {{! No image, show a simple file input }}
+            <input
+              class="text-df-yellow semibold border-dashed"
+              id="showArtwork"
+              name="showArtwork"
+              type="file"
+              accept="image/*"
+              {{on "change" this.updateFile}}
+            />
+          {{/if}}
+        {{/let}}
       </div>
+
+      {{! check if this is an archive  }}
       {{#if @episode.airDatePassed}}
-        <div class="">
-
-          <MyShows::RecordingSelector @changeset={{changeset}} />
-          <div class="my-2 flex justify-between">
-
+        <div>
+          <div class="my-2 flex justify-start gap-4">
             <label for="archive-status">
               {{t "profile.my-shows.form.archive-status"}}
             </label>
@@ -92,6 +112,7 @@
               {{/each-in}}
             </select>
           </div>
+          <MyShows::RecordingSelector @changeset={{changeset}} />
           <div class="my-2 py-2 border-2 border-red-400 border-dashed">
             <Form.Input
               @label={{t "profile.my-shows.form.youtube-link"}}
@@ -113,27 +134,39 @@
       {{else}}
         {{! airdate has *not* passed; its an upcoming show }}
         <div>
-          <TimePicker
-            @label="Start time"
-            @property="start"
-            @changeset={{changeset}}
-            @onChange={{this.setEndAfterStart}}
-          />
-          <TimePicker
-            @label="Duration"
-            @property="end"
-            @changeset={{changeset}}
-            @startTime={{changeset.start}}
-          />
+          <div class="flex justify-start gap-4 my-4">
+            <label>{{t "profile.my-shows.form.time-len"}}</label>
+            <TimePicker
+              @label="Start time"
+              @property="start"
+              @changeset={{changeset}}
+              @onChange={{this.setEndAfterStart}}
+            />
+            <TimePicker
+              @label="Duration"
+              @property="end"
+              @changeset={{changeset}}
+              @startTime={{changeset.start}}
+            />
+          </div>
         </div>
-        <h4>
-          {{t "profile.my-shows.form.prerecorded-set"}}
-        </h4>
-        <TrackUploader
-          @changeset={{changeset}}
-          @onStartUpload={{this.onStartUpload}}
-          @onFinishUpload={{this.onFinishUpload}}
-        />
+        <div class="flex justify-start gap-10 mb-4 relative">
+
+          <label>{{t "profile.my-shows.form.upload-new"}}</label>
+          <div class="flex justify-end gap-2">
+            <label class="italic text-xs text-white align-sub">
+              {{t "profile.my-shows.form.choose-file"}}
+            </label>
+            <input
+              class="text-df-yellow semibold border-dashed"
+              id="showArtwork"
+              name="showArtwork"
+              type="file"
+              accept="image/*"
+              {{on "change" this.updateFile}}
+            />
+          </div>
+        </div>
         {{#if changeset.prerecordTrackId}}
           {{changeset.prerecordTrackFilename}}
         {{/if}}

--- a/app/components/my-shows/episode-form.ts
+++ b/app/components/my-shows/episode-form.ts
@@ -47,13 +47,7 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
     if (!file) return;
 
     // Validate file type - only allow images
-    const validImageTypes = [
-      'image/jpeg',
-      'image/jpg',
-      'image/png',
-      'image/gif',
-      'image/webp',
-    ];
+    const validImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
     if (!validImageTypes.includes(file.type)) {
       alert(this.intl.t('profile.my-shows.form.invalid-file-type'));
       e.target.value = ''; // Clear the input

--- a/app/components/my-shows/episode-form.ts
+++ b/app/components/my-shows/episode-form.ts
@@ -21,10 +21,14 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
     Unpublished: 'archive_unpublished',
   };
 
-  @action deleteFile() {
-    console.log('delete file triggered');
-    this.file = null;
-    // not working yet
+  @action deleteFile(changeset: BufferedChangeset) {
+    if (changeset.get('image')) {
+      changeset.set('image', '');
+    }
+
+    if (changeset.get('thumbImageUrl')) {
+      changeset.set('thumbImageUrl', '');
+    }
   }
   @tracked isUploading: boolean = false;
 

--- a/app/components/my-shows/episode-form.ts
+++ b/app/components/my-shows/episode-form.ts
@@ -3,9 +3,8 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import type ScheduledShow from 'datafruits13/models/scheduled-show';
-import dayjs, { Dayjs } from "dayjs";
+import dayjs, { Dayjs } from 'dayjs';
 import { BufferedChangeset } from 'ember-changeset/types';
-
 interface MyShowsEpisodeFormArgs {
   episode: ScheduledShow;
 }
@@ -15,13 +14,18 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
   @service declare currentUser: any;
   @service declare intl: any;
 
-  file: Blob | null = null;
+  @tracked file: Blob | null = null;
 
   statusOptions = {
-    "Published": "archive_published",
-    "Unpublished": "archive_unpublished"
+    Published: 'archive_published',
+    Unpublished: 'archive_unpublished',
   };
 
+  @action deleteFile() {
+    console.log('delete file triggered');
+    this.file = null;
+    // not working yet
+  }
   @tracked isUploading: boolean = false;
 
   @action
@@ -34,12 +38,18 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
     this.isUploading = false;
   }
 
-  @action updateFile(e: any){
+  @action updateFile(e: any) {
     const file = e.target.files[0];
     if (!file) return;
 
     // Validate file type - only allow images
-    const validImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
+    const validImageTypes = [
+      'image/jpeg',
+      'image/jpg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ];
     if (!validImageTypes.includes(file.type)) {
       alert(this.intl.t('profile.my-shows.form.invalid-file-type'));
       e.target.value = ''; // Clear the input
@@ -73,7 +83,7 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
 
   @action
   deleteEpisode() {
-    if(confirm(this.intl.t('profile.my-shows.form.confirm-delete'))) {
+    if (confirm(this.intl.t('profile.my-shows.form.confirm-delete'))) {
       this.args.episode.destroyRecord().then(() => {
         alert(this.intl.t('profile.my-shows.form.episode-deleted'));
         //redirect to /my-shows
@@ -84,7 +94,7 @@ export default class MyShowsEpisodeForm extends Component<MyShowsEpisodeFormArgs
 
   @action
   setEndAfterStart(startTime: Dayjs, changeset: BufferedChangeset) {
-    if(startTime.hour() > dayjs(changeset.get('endAt')).hour()) {
+    if (startTime.hour() > dayjs(changeset.get('endAt')).hour()) {
       console.log('setting end time to: ', startTime.add(1, 'hour').hour());
       changeset.set('endTime', startTime.add(1, 'hour'));
     }

--- a/app/components/my-shows/recording-selector.hbs
+++ b/app/components/my-shows/recording-selector.hbs
@@ -1,0 +1,45 @@
+<div class="mb-2">
+  <div class="flex justify-around">
+    <label>
+      <input
+        type="radio"
+        name="recording-option"
+        value="prerecorded"
+        checked={{eq this.selectedOption "prerecorded"}}
+        {{on "change" (fn this.selectOption "prerecorded")}}
+        class="form-radio text-df-yellow"
+      />
+      <span class="my-1 text-sm">
+        {{t "profile.my-shows.form.select-recording"}}
+      </span>
+    </label>
+
+    <label>
+      <input
+        type="radio"
+        name="recording-option"
+        value="upload"
+        checked={{eq this.selectedOption "upload"}}
+        {{on "change" (fn this.selectOption "upload")}}
+        class="form-radio text-df-yellow"
+      />
+      <span class="my-1 text-sm">
+        {{t "profile.my-shows.form.upload-new"}}
+      </span>
+    </label>
+  </div>
+
+  {{! Conditionally render based on the selected option }}
+  {{#if (eq this.selectedOption "prerecorded")}}
+    <MyShows::RecordingsSearch @changeset={{@changeset}} />
+  {{else if (eq this.selectedOption "upload")}}
+    <TrackUploader @changeset={{@changeset}} />
+  {{/if}}
+
+  {{! Display selected file name, if it exists }}
+  {{#if @changeset.prerecordTrackFilename}}
+    <span
+      class="mt-2 text-xs italic"
+    >{{@changeset.prerecordTrackFilename}}</span>
+  {{/if}}
+</div>

--- a/app/components/my-shows/recording-selector.ts
+++ b/app/components/my-shows/recording-selector.ts
@@ -12,7 +12,6 @@ export default class RecordingSelectorComponent extends Component<RecordingSelec
 
   constructor(owner: unknown, args: RecordingSelectorArgs) {
     super(owner, args);
-    this.initializeSelectedOption();
   }
 
   @action
@@ -25,18 +24,6 @@ export default class RecordingSelectorComponent extends Component<RecordingSelec
     } else if (option === 'prerecorded') {
       this.args.changeset.set('prerecordTrackFile', null);
       this.args.changeset.set('prerecordTrackFilename', null);
-    }
-  }
-
-  private initializeSelectedOption(): void {
-    const { changeset } = this.args;
-    if (
-      changeset.get('prerecordTrackId') ||
-      changeset.get('usePrerecordedFileForArchive')
-    ) {
-      this.selectedOption = 'prerecorded';
-    } else {
-      this.selectedOption = 'upload';
     }
   }
 }

--- a/app/components/my-shows/recording-selector.ts
+++ b/app/components/my-shows/recording-selector.ts
@@ -10,10 +10,6 @@ interface RecordingSelectorArgs {
 export default class RecordingSelectorComponent extends Component<RecordingSelectorArgs> {
   @tracked selectedOption: 'prerecorded' | 'upload' = 'prerecorded';
 
-  constructor(owner: unknown, args: RecordingSelectorArgs) {
-    super(owner, args);
-  }
-
   @action
   selectOption(option: 'prerecorded' | 'upload'): void {
     this.selectedOption = option;

--- a/app/components/my-shows/recording-selector.ts
+++ b/app/components/my-shows/recording-selector.ts
@@ -1,0 +1,42 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { BufferedChangeset } from 'ember-changeset/types';
+
+interface RecordingSelectorArgs {
+  changeset: BufferedChangeset;
+}
+
+export default class RecordingSelectorComponent extends Component<RecordingSelectorArgs> {
+  @tracked selectedOption: 'prerecorded' | 'upload' = 'prerecorded';
+
+  constructor(owner: unknown, args: RecordingSelectorArgs) {
+    super(owner, args);
+    this.initializeSelectedOption();
+  }
+
+  @action
+  selectOption(option: 'prerecorded' | 'upload'): void {
+    this.selectedOption = option;
+
+    if (option === 'upload') {
+      this.args.changeset.set('prerecordTrackId', null);
+      this.args.changeset.set('usePrerecordedFileForArchive', false);
+    } else if (option === 'prerecorded') {
+      this.args.changeset.set('prerecordTrackFile', null);
+      this.args.changeset.set('prerecordTrackFilename', null);
+    }
+  }
+
+  private initializeSelectedOption(): void {
+    const { changeset } = this.args;
+    if (
+      changeset.get('prerecordTrackId') ||
+      changeset.get('usePrerecordedFileForArchive')
+    ) {
+      this.selectedOption = 'prerecorded';
+    } else {
+      this.selectedOption = 'upload';
+    }
+  }
+}

--- a/app/components/track-uploader.hbs
+++ b/app/components/track-uploader.hbs
@@ -1,10 +1,14 @@
 {{#let (file-queue name="track" onFileAdded=this.uploadTrack) as |queue|}}
-  <label>
-    {{t "profile.my-shows.form.choose-file"}}
-    <input type="file" {{queue.selectFile}}>
-  </label>
+  <div class="flex justify-end">
+    <label class="italic text-xs text-white align-sub">
+      {{t "profile.my-shows.form.choose-file"}}
+    </label>
+    <input class="mx-1" type="file" {{queue.selectFile}} />
+  </div>
 
   {{#if queue.files.length}}
-    Uploading {{queue.files.length}} files. ({{queue.progress}}%)
+    Uploading
+    {{queue.files.length}}
+    files. ({{queue.progress}}%)
   {{/if}}
 {{/let}}

--- a/app/components/track-uploader.ts
+++ b/app/components/track-uploader.ts
@@ -6,7 +6,6 @@ import fetch from 'fetch';
 import type { BufferedChangeset } from 'ember-changeset/types';
 //import type { UploadFile } from 'ember-file-upload/upload-file';
 
-
 interface TrackUploaderArgs {
   changeset: BufferedChangeset;
   onStartUpload: () => void | null;
@@ -16,8 +15,9 @@ interface TrackUploaderArgs {
 export default class TrackUploader extends Component<TrackUploaderArgs> {
   @service declare store: any;
   @service declare session: any;
+  declare enabled: boolean;
 
-  signingUrl = `${ENV.API_HOST}/uploader_signature`;
+  signingUrl = `${ENV.API_HOST}/uploader_signatu  re`;
 
   validMimeTypes = ['audio/mp3', 'audio/mpeg'];
 
@@ -25,15 +25,15 @@ export default class TrackUploader extends Component<TrackUploaderArgs> {
   uploadTrack(file: any) {
     window.onbeforeunload = function (e) {
       const dialogText =
-        'You are currently uploading files. Closing this tab will cancel the upload operation! Are you usure you want to close this tab?';
+        'You are currently uploading files. Closing this tab will cancel the upload operation! Are you sure you want to close this tab?';
       e.returnValue = dialogText;
       return dialogText;
     };
-    if(typeof this.args.onStartUpload == 'function') {
+    if (typeof this.args.onStartUpload == 'function') {
       this.args.onStartUpload();
     }
 
-    if(!this.validMimeTypes.includes(file.type)) {
+    if (!this.validMimeTypes.includes(file.type)) {
       alert('Only mp3 is supported! sorry...');
       return;
     }
@@ -54,7 +54,11 @@ export default class TrackUploader extends Component<TrackUploaderArgs> {
       'Content-Type': mimeType,
       'x-amz-acl': 'public-read',
     };
-    const params = { 'name': file.name.toString(), 'size': file.size.toString(), 'type': file.type.toString() };
+    const params = {
+      name: file.name.toString(),
+      size: file.size.toString(),
+      type: file.type.toString(),
+    };
     const searchParams = new URLSearchParams(Object.entries(params)).toString();
     fetch(`${this.signingUrl}?${searchParams}`, {
       headers: {
@@ -64,13 +68,16 @@ export default class TrackUploader extends Component<TrackUploaderArgs> {
       .then((response) => response.json())
       .then((data) => {
         track.set('audioFileName', data.endpoint.split('?')[0]);
-        return file.uploadBinary(data.endpoint, { method: 'PUT', headers: headers });
+        return file.uploadBinary(data.endpoint, {
+          method: 'PUT',
+          headers: headers,
+        });
       })
       .then((response) => {
         console.log(`uploaded: ${response}`);
         console.log(response);
         track.set('isUploading', false);
-        if(typeof this.args.onFinishUpload == 'function') {
+        if (typeof this.args.onFinishUpload == 'function') {
           this.args.onFinishUpload();
         }
         track
@@ -80,7 +87,10 @@ export default class TrackUploader extends Component<TrackUploaderArgs> {
             //this.flashMessages.success('Track uploaded!');
             window.onbeforeunload = null;
             this.args.changeset.set('prerecordTrackId', track.id);
-            this.args.changeset.set('prerecordTrackFilename', track.audioFileName);
+            this.args.changeset.set(
+              'prerecordTrackFilename',
+              track.audioFileName
+            );
           })
           .catch((reason: any) => {
             console.log(`track save failed: ${reason}`);

--- a/app/components/track-uploader.ts
+++ b/app/components/track-uploader.ts
@@ -17,7 +17,7 @@ export default class TrackUploader extends Component<TrackUploaderArgs> {
   @service declare session: any;
   declare enabled: boolean;
 
-  signingUrl = `${ENV.API_HOST}/uploader_signatu  re`;
+  signingUrl = `${ENV.API_HOST}/uploader_signature`;
 
   validMimeTypes = ['audio/mp3', 'audio/mpeg'];
 

--- a/app/components/track-uploader.ts
+++ b/app/components/track-uploader.ts
@@ -15,7 +15,6 @@ interface TrackUploaderArgs {
 export default class TrackUploader extends Component<TrackUploaderArgs> {
   @service declare store: any;
   @service declare session: any;
-  declare enabled: boolean;
 
   signingUrl = `${ENV.API_HOST}/uploader_signature`;
 

--- a/app/helpers/episode-image-url.js
+++ b/app/helpers/episode-image-url.js
@@ -1,0 +1,11 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function episodeImageUrl([changeset]) {
+  if (changeset.image) {
+    return changeset.image;
+  }
+  if (changeset.thumbImageUrl) {
+    return changeset.thumbImageUrl;
+  }
+  return null;
+});

--- a/app/models/scheduled-show.js
+++ b/app/models/scheduled-show.js
@@ -117,8 +117,4 @@ export default class ScheduledShow extends Model {
   get airDatePassed() {
     return new Date(this.end) < new Date();
   }
-
-  get isUsingPrerecord() {
-    return !this.usePrerecordedFileForArchive;
-  }
 }

--- a/app/models/scheduled-show.js
+++ b/app/models/scheduled-show.js
@@ -5,23 +5,26 @@ export default class ScheduledShow extends Model {
   @belongsTo('recording', { async: false, inverse: null }) recording;
   @hasMany('post', {
     async: false,
-    inverse: null
-  }) posts;
+    inverse: null,
+  })
+  posts;
   @hasMany('label', {
     async: false,
-    inverse: null
-  }) labels;
+    inverse: null,
+  })
+  labels;
   @hasMany('track', {
     async: false,
-    inverse: 'scheduledShow'
-  }) tracks;
+    inverse: 'scheduledShow',
+  })
+  tracks;
 
   // TODO merge user/dj model
   @hasMany('user', {
     async: false,
-    inverse: null
-  }) djs;
-
+    inverse: null,
+  })
+  djs;
 
   @attr()
   start;
@@ -104,7 +107,7 @@ export default class ScheduledShow extends Model {
   }
 
   get imageOrDefault() {
-    if(this.imageUrl) {
+    if (this.imageUrl) {
       return this.imageUrl;
     } else {
       return this.showSeries.get('imageUrl');
@@ -113,5 +116,9 @@ export default class ScheduledShow extends Model {
 
   get airDatePassed() {
     return new Date(this.end) < new Date();
+  }
+
+  get isUsingPrerecord() {
+    return !this.usePrerecordedFileForArchive;
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -235,7 +235,7 @@
       "form": {
         "title": "Title",
         "description": "Description",
-        "artwork": "Default Artwork",
+        "artwork": "Artwork",
         "start": "Date/Time",
         "end": "End",
         "repeating": "Repeating or one off",
@@ -251,6 +251,7 @@
         "air-date": "Air date:",
         "archive": "ARCHIVE",
         "select-recording": "Select recording",
+        "upload-new": "Upload a set",
         "archive-status": "Archive Status",
         "confirm-delete": "Are you sure?!!!",
         "episode-deleted": "Goodbye episode. :(",

--- a/translations/en.json
+++ b/translations/en.json
@@ -238,6 +238,7 @@
         "artwork": "Artwork",
         "start": "Date/Time",
         "end": "End",
+        "time-len": "Time/Duration",
         "repeating": "Repeating or one off",
         "youtube-link": "Youtube URL",
         "mixcloud-link": "Mixcloud URL",

--- a/translations/es.json
+++ b/translations/es.json
@@ -4,7 +4,13 @@
     "return_linktext": "volver a la seguridad"
   },
   "profile": {
-    "favorites": "Favoritas"
+    "favorites": "Favoritas",
+    "my-shows": {
+      "form": {
+        "artwork": "Obra de arte",
+        "upload-new": "Subir un conjunto"
+      }
+    }
   },
   "usermenu": {
     "settings": "Editar perfil",

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -72,9 +72,10 @@
       "form": {
         "title": "タイトル",
         "description": "詳細",
-        "artwork": "画像",
+        "artwork": "アートワーク",
         "start": "日付/時間",
         "end": "End",
+        "upload-new": "セットをアップロードする",
         "repeating": "Repeating or one off",
         "youtube-link": "YoutubeのURL",
         "mixcloud-link": "MixcloudのURL",

--- a/translations/ko.json
+++ b/translations/ko.json
@@ -73,7 +73,7 @@
       "form": {
         "title": "제목",
         "description": "설명",
-        "artwork": "아트워크",
+        "artwork": "예술 작품",
         "start": "날짜/시간",
         "end": "끝",
         "repeating": "반복 또는 일회성",
@@ -84,6 +84,7 @@
         "update": "저장",
         "delete": "에피소드 삭제",
         "prerecorded-set": "사전 녹음 세트",
+        "upload-new": "세트 업로드",
         "choose-file": "파일 선택",
         "invalid-file-type": "아트워크에는 이미지 파일(JPEG, PNG, GIF, WebP)만 허용됩니다!",
         "air-date": "방송 날짜:",

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -8,7 +8,13 @@
     "events": "活動"
   },
   "profile": {
-    "favorites": "收藏夹"
+    "favorites": "收藏夹",
+    "my-shows": {
+      "form": {
+        "artwork": "艺术品",
+        "upload-new": "上传一组"
+      }
+    }
   },
   "chat": {
     "title": "聊天室",


### PR DESCRIPTION
### preface
maintaining archives is pretty easy, but there's some visual clunkiness that's making it hard to navigate the form and understand if you should check this box to select or what, so I tried redoing some things to make it look uniform and manageable. 

#### changes
I'd like the title of the page say "Editing episode of {title}" or something, so I added a little text that says (episode update form). Then we got the air-date, title, description, tags, and artwork
<img width="860" height="960" alt="image" src="https://github.com/user-attachments/assets/d44e4b51-d379-494a-9fb4-9c542c491ca9" />
I'd like to have the dashed-border overlayed over the image and the button floating over the bottom-right of it (like the webcam feature noone uses). below the artwork is the new radio group to either Select a recording or Upload a set

<img width="888" height="550" alt="image" src="https://github.com/user-attachments/assets/775088a7-7bfa-4e0b-9ddc-416536bfe648" />

Here's the part where I used some AI.  The "Upload a set" shows the file upload

<img width="867" height="559" alt="image" src="https://github.com/user-attachments/assets/5d605207-b606-4555-ad99-8b5dd2ca09d4" />

And then there's the Archive status button and the rest of the form. I grouped the social media links together to make it a little more clear whats going on. I haven't really tested it yet because I don't want to keep posting test data but yeah what do we think so far?