### PR TITLE
Copy .env.sample in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      - name: Create .env from sample
+        run: cp .env.sample .env
+
       # Install dependencies
       - name: Install dependencies
         run: pnpm install
@@ -85,6 +88,9 @@ jobs:
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
+
+      - name: Create .env from sample
+        run: cp .env.sample .env
 
       # Install dependencies
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- create .env from .env.sample in the lint job
- create .env from .env.sample in the test job
- preserve CI behavior after removing tracked .env

## Testing
- not run locally (workflow-only change)