### PR TITLE
fix: unreachable horizontal overflow on small screens

### DIFF
--- a/app/components/datafruits-chat.hbs
+++ b/app/components/datafruits-chat.hbs
@@ -44,7 +44,7 @@
       {{else}}
         <form align="center" class="mb-3" {{on "submit" this.enterChatAnonymously}}>
           {{!-- Nickname input + Join chat button --}}
-          <div class="flex justify-center">
+          <div class="flex justify-center flex-col md:flex-row">
             <label for="nick">{{t "chat.label.nick"}}</label>
             <Input
               @type="text"

--- a/app/templates/home/shows/episode.hbs
+++ b/app/templates/home/shows/episode.hbs
@@ -62,7 +62,7 @@
         {{/each}}
       </div>
       <div>
-        <h1>{{t "show.episode.comments"}}</h1>
+        <h1 class="break-all md:break-normal">{{t "show.episode.comments"}}</h1>
         <section class="mb-4">
           {{#if this.session.isAuthenticated}}
             <h1 class="text-2xl font-cursive mb-2">Hey, {{this.currentUser.user.username}}, {{t "show.episode.leave_a_comment"}}</h1>


### PR DESCRIPTION
Tested using responsive mode in OSX Safari
Generally if the icon is in the top-right I'm calling it good.

<table>
<tr><th>
Chat screen 
(unauthed) before
</th><th>
after
</th>
</tr>
<tr>
<td>
<img width="352" height="688" alt="Screenshot 2026-07-19 at 12 19 31 AM" src="https://github.com/user-attachments/assets/b5c0ce73-2301-462b-bbef-a6eadd80f303" />
</td>
<td>
<img width="375" height="707" alt="Screenshot 2026-07-19 at 12 18 53 AM" src="https://github.com/user-attachments/assets/64448138-4a27-4154-9363-04c98528c176" />
</td>
</tr>
</table>

<table>
<tr><th>
Podcast episode before
</th><th>
after
</th>
</tr>
<tr>
<td>
<img width="371" height="700" alt="Screenshot 2026-07-19 at 12 19 53 AM" src="https://github.com/user-attachments/assets/5c3d6c2d-3778-4991-91e2-5aa3af6df14c" />
</td>
<td>
<img width="373" height="720" alt="Screenshot 2026-07-19 at 12 20 10 AM" src="https://github.com/user-attachments/assets/edf9b003-1914-48d5-a45f-77982b5652c8" />
</td>
</tr>
</table>
